### PR TITLE
feat: Fix navigation bar issues

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -17,14 +17,24 @@
             <div class="accordion-group">
                 <div class="accordion-heading">
                     <li class="nginx-toc-link l1">
-                        <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle" aria-expanded="false"
+                        {{ $theRealSection := (print "/"   $.Section  "/") }}
+                        {{ if eq .RelPermalink $theRealSection }}
+                            <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle" aria-expanded="true"
+                        {{ else }}
+                            <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle" aria-expanded="false"
+                        {{ end }}
                             data-toggle="collapse" href="#" data-target="#{{.Section | urlize}}--{{.Title | urlize}}--collapseOne"
                             aria-controls="{{.Section | urlize}}--{{.Title | urlize}}--collapseOne">
                             <i class="fa fa-sm fa-fw fa-chevron-right"></i><i
                                 class="fa fa-sm fa-fw fa-chevron-down"></i>{{ .Title }}</a>
                     </li>
                 </div>
+<!-- This is necessary to expand the current product after clicking on the product cards in docs.nginx.com-->
+                {{ if eq .RelPermalink $theRealSection }}
+                <div id="{{.Section | urlize}}--{{.Title | urlize}}--collapseOne" class="accordion-body collapse show">
+                {{ else }}
                 <div id="{{.Section | urlize}}--{{.Title | urlize}}--collapseOne" class="accordion-body collapse">
+                {{ end }}
                     <div class="accordion-inner">
                         {{ range .Sections }}
                         <div class="accordion" id="accordion2">
@@ -58,16 +68,49 @@
                                                                 </li>
                                                             <ul>
                                                         </div>
+
                                                         <div id="{{.Section | urlize}}--{{.Title | urlize}}--collapseThree" class="accordion-body collapse leaf">
                                                             <div class="accordion-inner">
-                                                            {{ range .Pages }}
-                                                            <ul class="sidebar-l2-padding">
-                                                                <li class="nginx-toc-link l3 sidebar-il-border ">
-                                                                    <a data-menu-id="{{.RelPermalink}}"
-                                                                        href="{{ .Permalink }}">{{ .Title }}</a>
-                                                                </li>
-                                                            </ul>
-                                                            {{ end }}
+                                                                {{ range .Sections }}
+                                                                <div class="accordion" id="Accordion4">
+                                                                    <div class="sidebar-l2-padding">
+                                                                        <div class="accordion-group sidebar-il-border">
+                                                                            <div class="accordion-heading">
+                                                                                <ul>
+                                                                                    <li class="nginx-toc-link l2">
+                                                                                        <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle"
+                                                                                            aria-expanded="false" data-toggle="collapse"
+                                                                                            href="#{{.Section | urlize}}--{{.Title | urlize}}--collapseFour">
+                                                                                            <i class="fa fa-sm fa-fw fa-chevron-right"></i><i
+                                                                                                class="fa fa-sm fa-fw fa-chevron-down"></i>{{ .Title }}</a>
+                                                                                    </li>
+                                                                                <ul>
+                                                                            </div>
+
+                                                                            <div id="{{.Section | urlize}}--{{.Title | urlize}}--collapseFour" class="accordion-body collapse leaf">
+                                                                                <div class="accordion-inner">
+                                                                                {{ range .Pages }}
+                                                                                <ul class="sidebar-l2-padding">
+                                                                                    <li class="nginx-toc-link l3 sidebar-il-border ">
+                                                                                        <a data-menu-id="{{.RelPermalink}}"
+                                                                                            href="{{ .Permalink }}">{{ .Title }}</a>
+                                                                                    </li>
+                                                                                </ul>
+                                                                                {{ end }}
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                                {{ end }}
+                                                                {{ range .RegularPages }}
+                                                                <ul class="sidebar-l2-padding">
+                                                                    <li class="nginx-toc-link l3 sidebar-il-border ">
+                                                                        <a data-menu-id="{{.RelPermalink}}"
+                                                                            href="{{ .Permalink }}">{{ .Title }}</a>
+                                                                    </li>
+                                                                </ul>
+                                                                {{ end }}  
                                                             </div>
                                                         </div>
                                                     </div>


### PR DESCRIPTION
### Proposed changes

- Add a 4th level to the navigation bar (fixes sections that stopped working after being pushed 1 level deeper)
- When loading one product's landing page, the Level 1 sections for the product expand automatically

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
