### PR TITLE
feat: weight order affects sections/pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 <!--- next entry here -->
 
+## 0.31.1
+2023-06-06
+
+### Fixes
+
+- sections and pages are now sorter by weight, mixed (5556d9dc2a0fcf477f4a740d061ed7ea7a9a11c7)
+
 ## 0.27.1
 2023-03-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 ### Fixes
 
-- sections and pages are now sorter by weight, mixed (5556d9dc2a0fcf477f4a740d061ed7ea7a9a11c7)
+- sections and pages are now sorted by weight, mixed (5556d9dc2a0fcf477f4a740d061ed7ea7a9a11c7)
 
 ## 0.27.1
 2023-03-13

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -12,126 +12,42 @@
             {{.Site.Title}}</a>
     </h3>
     <ul>
-        {{ range .Site.Sections }}
+    {{ range where .Site.Pages.ByWeight "Section" "=" "" }}
+    {{ range .Pages.ByWeight }}
+        {{if eq .Kind "page"}}<!-- Level 1 Regular Pages -->
+        <!-- Create a regular list item for pages -->
+        <ul class="sidebar-reg-padding">
+            <div class="accordion" id="accordion1">
+                <div class="accordion-group">
+                    <div class="accordion-heading">
+                        <ul>
+                            <li class="nginx-toc-link l1">
+                                <a data-menu-id="{{.RelPermalink}}"
+                                    href="{{ .Permalink }}">{{ .Title }}</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </ul>
+        <!-- Create an accordion group for Level 1 sections -->
+        {{ else }}
         <div class="accordion" id="accordion1">
             <div class="accordion-group">
                 <div class="accordion-heading">
                     <li class="nginx-toc-link l1">
-                        {{ $theRealSection := (print "/"   $.Section  "/") }}
-                        {{ if eq .RelPermalink $theRealSection }}
-                            <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle" aria-expanded="true"
-                        {{ else }}
-                            <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle" aria-expanded="false"
-                        {{ end }}
+                        <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle" aria-expanded="false"
                             data-toggle="collapse" href="#" data-target="#{{.Section | urlize}}--{{.Title | urlize}}"
                             aria-controls="{{.Section | urlize}}--{{.Title | urlize}}">
                             <i class="fa fa-sm fa-fw fa-chevron-right"></i><i
                                 class="fa fa-sm fa-fw fa-chevron-down"></i>{{ .Title }}</a>
                     </li>
                 </div>
-<!-- This is necessary to expand the current product after clicking on the product cards in docs.nginx.com-->
-                {{ if eq .RelPermalink $theRealSection }}
-                <div id="{{.Section | urlize}}--{{.Title | urlize}}" class="accordion-body collapse show">
-                {{ else }}
                 <div id="{{.Section | urlize}}--{{.Title | urlize}}" class="accordion-body collapse">
-                {{ end }}
                     <div class="accordion-inner">
-                        {{ range .Sections }}
-                        <div class="accordion" id="accordion2">
-                            <div class="sidebar-l1-padding">
-                                <div class="accordion-group sidebar-il-border">
-                                    <div class="accordion-heading">
-                                        <ul>
-                                            <li class="nginx-toc-link l2">
-                                                <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle"
-                                                    aria-expanded="false" data-toggle="collapse"
-                                                    href="#{{.Section | urlize}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}">
-                                                    <i class="fa fa-sm fa-fw fa-chevron-right"></i><i
-                                                        class="fa fa-sm fa-fw fa-chevron-down"></i>{{ .Title }}</a>
-                                            </li>
-                                        <ul>
-                                    </div>
-                                    <div id="{{.Section | urlize}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}" class="accordion-body collapse leaf">
-                                        <div class="accordion-inner">
-                                            {{ range .Sections }}
-                                            <div class="accordion" id="Accordion3">
-                                                <div class="sidebar-l2-padding">
-                                                    <div class="accordion-group sidebar-il-border">
-                                                        <div class="accordion-heading">
-                                                            <ul>
-                                                                <li class="nginx-toc-link l2">
-                                                                    <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle"
-                                                                        aria-expanded="false" data-toggle="collapse"
-                                                                        href="#{{.Section | urlize}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}">
-                                                                        <i class="fa fa-sm fa-fw fa-chevron-right"></i><i
-                                                                            class="fa fa-sm fa-fw fa-chevron-down"></i>{{ .Title }}</a>
-                                                                </li>
-                                                            <ul>
-                                                        </div>
-
-                                                        <div id="{{.Section | urlize}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}" class="accordion-body collapse leaf">
-                                                            <div class="accordion-inner">
-                                                                {{ range .Sections }}
-                                                                <div class="accordion" id="Accordion4">
-                                                                    <div class="sidebar-l2-padding">
-                                                                        <div class="accordion-group sidebar-il-border">
-                                                                            <div class="accordion-heading">
-                                                                                <ul>
-                                                                                    <li class="nginx-toc-link l2">
-                                                                                        <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle"
-                                                                                            aria-expanded="false" data-toggle="collapse"
-                                                                                            href="#{{.Section | urlize}}--{{.Parent.Parent.File.ContentBaseName}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}">
-                                                                                            <i class="fa fa-sm fa-fw fa-chevron-right"></i><i
-                                                                                                class="fa fa-sm fa-fw fa-chevron-down"></i>{{ .Title }}</a>
-                                                                                    </li>
-                                                                                <ul>
-                                                                            </div>
-
-                                                                            <div id="{{.Section | urlize}}--{{.Parent.Parent.File.ContentBaseName}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}" class="accordion-body collapse leaf">
-                                                                                <div class="accordion-inner">
-                                                                                {{ range .Pages }}
-                                                                                <ul class="sidebar-l2-padding">
-                                                                                    <li class="nginx-toc-link l3 sidebar-il-border ">
-                                                                                        <a data-menu-id="{{.RelPermalink}}"
-                                                                                            href="{{ .Permalink }}">{{ .Title }}</a>
-                                                                                    </li>
-                                                                                </ul>
-                                                                                {{ end }}
-                                                                                </div>
-                                                                            </div>
-                                                                        </div>
-                                                                    </div>
-                                                                </div>
-                                                                {{ end }}
-                                                                {{ range .RegularPages }}
-                                                                <ul class="sidebar-l2-padding">
-                                                                    <li class="nginx-toc-link l3 sidebar-il-border ">
-                                                                        <a data-menu-id="{{.RelPermalink}}"
-                                                                            href="{{ .Permalink }}">{{ .Title }}</a>
-                                                                    </li>
-                                                                </ul>
-                                                                {{ end }}  
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            {{ end }}
-                                            {{ range .RegularPages }}
-                                            <ul class="sidebar-l2-padding">
-                                                <li class="nginx-toc-link l3 sidebar-il-border ">
-                                                    <a data-menu-id="{{.RelPermalink}}"
-                                                        href="{{ .Permalink }}">{{ .Title }}</a>
-                                                </li>
-                                            </ul>
-                                            {{ end }}                                            
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        {{ end }}
-                        {{ range .RegularPages }}
+                    {{ range .Pages.ByWeight }}<!-- Level 2 Regular Pages -->
+                    <!-- Create a regular list item for pages -->
+                        {{if eq .Kind "page"}}
                         <ul class="sidebar-reg-padding">
                             <div class="accordion" id="accordion2">
                                 <div class="accordion-group sidebar-il-border">
@@ -146,20 +62,140 @@
                                 </div>
                             </div>
                         </ul>
+                        <!-- Create an accordion group for Level 2 sections -->
+                        {{ else }}
+                        <div class="accordion" id="Accordion2">
+                            <div class="sidebar-l1-padding">
+                                <div class="accordion-group sidebar-il-border">
+                                    <div class="accordion-heading">
+                                        <ul>
+                                            <li class="nginx-toc-link l2">
+                                                <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle"
+                                                    aria-expanded="false" data-toggle="collapse"
+                                                    href="#{{.Section | urlize}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}">
+                                                    <i class="fa fa-2xs fa-fw fa-chevron-right"></i><i
+                                                        class="fa fa-2xs fa-fw fa-chevron-down"></i>{{ .Title }}</a>
+                                            </li>
+                                        <ul>
+                                    </div>
+                                    <div id="{{.Section | urlize}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}" class="accordion-body collapse leaf">
+                                        <div class="accordion-inner">
+
+                                        {{ range .Pages.ByWeight }}<!-- Level 3 Regular Pages -->
+                                            <!-- Create a regular list item for pages -->
+                                            {{if eq .Kind "page"}}
+                                            <ul class="sidebar-l2-padding">
+                                                <li class="nginx-toc-link l3 sidebar-il-border">
+                                                    <a data-menu-id="{{.RelPermalink}}" href="{{ .Permalink }}">{{ .Title }}</a>
+                                                </li>
+                                            </ul>                                            
+                                            <!-- Create an accordion group for Level 3 sections -->
+                                            {{else}}
+                                            <div class="accordion" id="Accordion3">
+                                                <div class="sidebar-l2-padding">
+                                                    <div class="accordion-group sidebar-il-border">
+                                                        <div class="accordion-heading">
+                                                            <ul>
+                                                                <li class="nginx-toc-link l2">
+                                                                    <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle"
+                                                                        aria-expanded="false" data-toggle="collapse"
+                                                                        href="#{{.Section | urlize}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}">
+                                                                        <i class="fa fa-2xs fa-fw fa-chevron-right"></i><i
+                                                                            class="fa fa-2xs fa-fw fa-chevron-down"></i>{{ .Title }}</a>
+                                                                </li>
+                                                            <ul>
+                                                        </div>
+                                                        <div id="{{.Section | urlize}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}" class="accordion-body collapse leaf">
+                                                            <div class="accordion-inner">
+                                                            {{ range .Pages.ByWeight }}<!-- Level 4 Regular Pages -->
+                                                            <!-- Create a regular list item for pages -->
+                                                            {{if eq .Kind "page"}}
+                                                                <ul class="sidebar-l2-padding">
+                                                                    <li class="nginx-toc-link l3 sidebar-il-border ">
+                                                                        <a data-menu-id="{{.RelPermalink}}"
+                                                                            href="{{ .Permalink }}">{{ .Title }}</a>
+                                                                    </li>
+                                                                </ul>
+                                                            <!-- Create an accordion group for Level 4 sections -->
+                                                            {{else}}
+                                                                <div class="accordion" id="Accordion4">
+                                                                    <div class="sidebar-l2-padding">
+                                                                        <div class="accordion-group sidebar-il-border">
+                                                                            <div class="accordion-heading">
+                                                                                <ul>
+                                                                                    <li class="nginx-toc-link l2">
+                                                                                        <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle"
+                                                                                            aria-expanded="false" data-toggle="collapse"
+                                                                                            href="#{{.Section | urlize}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}">
+                                                                                            <i class="fa fa-2xs fa-fw fa-chevron-right"></i><i
+                                                                                                class="fa fa-2xs fa-fw fa-chevron-down"></i>{{ .Title }}</a>
+                                                                                    </li>
+                                                                                <ul>
+                                                                            </div>
+                                                                            <div id="{{.Section | urlize}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}" class="accordion-body collapse leaf">
+                                                                                <div class="accordion-inner">
+                                                                                    {{ range .Pages.ByWeight }}<!-- Level 5 Regular Pages -->
+                                                                                    <!-- Create a regular list item for pages -->
+                                                                                    {{if eq .Kind "page"}}
+                                                                                    <ul class="sidebar-l2-padding">
+                                                                                        <li class="nginx-toc-link l3 sidebar-il-border ">
+                                                                                            <a data-menu-id="{{.RelPermalink}}"
+                                                                                                href="{{ .Permalink }}">{{ .Title }}</a>
+                                                                                        </li>
+                                                                                    </ul>
+                                                                                    <!-- Create an accordion group for Level 5sections -->
+                                                                                    {{else}}    
+                                                                                    <div class="accordion" id="Accordion5">
+                                                                                        <div class="sidebar-l2-padding">
+                                                                                            <div class="accordion-group sidebar-il-border">
+                                                                                                <div class="accordion-heading">
+                                                                                                    <ul>
+                                                                                                        <li class="nginx-toc-link l2">
+                                                                                                            <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle"
+                                                                                                                aria-expanded="false" data-toggle="collapse"
+                                                                                                                href="#{{.Section | urlize}}--{{.Parent.File.ContentBaseName}}--{{.Title | urlize}}">
+                                                                                                                <i class="fa fa-2xs fa-fw fa-chevron-right"></i><i
+                                                                                                                    class="fa fa-2xs fa-fw fa-chevron-down"></i>{{ .Title }}</a>
+                                                                                                        </li>
+                                                                                                    <ul>
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        </div>
+                                                                                    </div>
+                                                                                    {{ end }}
+                                                                                    {{ end }}
+                                                                                </div>
+                                                                            </div>
+                                                                        </div>
+                                                                    </div>
+                                                                </div>
+                                                                {{ end }}
+                                                                {{ end }}  
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            {{ end }}
+                                        {{ end }}                                        
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
                         {{ end }}
+                    {{ end }}
                     </div>
                 </div>
             </div>
-        </div>
+        </div> 
         {{ end }}
-    </ul>
-    {{ range where .Site.RegularPages "Section" "=" "" }}
-    <ul>
-        <li class="nginx-toc-link l1">
-            <a data-menu-id="{{.RelPermalink}}" href="{{ .Permalink }}">{{ .Title }}</a>
-        </li>
-    </ul>
     {{ end }}
+{{ end }}
+
+</ul>
+
+<!-- close sidebar div-->
 </div>
 {{ end }}
 


### PR DESCRIPTION
### Proposed changes

This change in the sidebar allows single pages to show before sections of the same depth level, based on the frontmatter weights.

Before:

![image](https://github.com/nginxinc/nginx-hugo-theme/assets/78599298/1480dd28-07d2-40eb-8276-5a24cc30bc9e)


After:

![image](https://github.com/nginxinc/nginx-hugo-theme/assets/78599298/1bb68f71-a844-4000-8b27-36cc75934b52)


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
