### PR TITLE
fix: added icon-info shortcode

### DIFF
--- a/layouts/shortcodes/icon-info.html
+++ b/layouts/shortcodes/icon-info.html
@@ -1,0 +1,1 @@
+<i class="fa-solid fa-circle-info" style="color:#1d9cd3;"></i>


### PR DESCRIPTION
### Proposed changes

- Created an icon-info shortcode to be used in RNs and KI docs.
- Resolves https://nginxsoftware.atlassian.net/browse/DOC-199

Looks like this:

<img width="229" alt="image" src="https://github.com/nginxinc/nginx-hugo-theme/assets/33876974/cb599a9c-e18e-45ba-b1ec-54f67bc4bf84">
