### PR TITLE
fix: copy button on non highlight blocks

### DIFF
--- a/assets/js/code-copy.js
+++ b/assets/js/code-copy.js
@@ -25,8 +25,6 @@ function CopyCode(clipboard) {
         if (pre.parentNode.classList.contains('highlight')) {
             var highlight = pre.parentNode;
             highlight.parentNode.insertBefore(button, highlight);
-        } else {
-            pre.parentNode.insertBefore(button, pre);
         }
     });
 }


### PR DESCRIPTION
### Proposed changes

Change to make the copy button work only with highlighted code blocks

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
