### PR TITLE
fix: update urls in meta CSP to allow netlify and cloudcannon js to run in-page

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -41,7 +41,7 @@
 {{/* set custom CSP to load styles and scripts with special handling for GTM scripts (requires unsafe-inline) and Dev Portal page(s) (requires 'unsafe-eval') */}}
 <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'
     https://consent.trustarc.com/ https://mktg.tags.f5.com/basic/prod/utag.sync.js https://static.cloud.coveo.com/ https://*.f5.com/
-    https://*.netlify.app https://gist.github.com 
+    https://app.netlify.com https://gist.github.com https://cdn.cloudcannon.com
     https://tag.demandbase.com/pscSDsz4.min.js
     https://munchkin.brightfunnel.com/js/build/bf-munchkin.min.js
     https://www.googletagmanager.com/gtm.js


### PR DESCRIPTION
### Proposed changes

- Updates the netlify URL in the CSP to match what is in use  
- Adds the cloudcannon URL to the CSP to allow in-page editing


