### PR TITLE
fix: fix explore button border

### DIFF
--- a/assets/css/f5-hugo.css
+++ b/assets/css/f5-hugo.css
@@ -1205,6 +1205,12 @@ ol.breadcrumb > li:first-child {
     padding-bottom: 0!important;
 }
 
+.nav-item-explore {
+    background: none;
+    position: relative;
+    padding-bottom: 0!important;
+}
+
 li.nav-item a.nav-link {
     color: #898787;
     font-weight: 300;

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -27,7 +27,7 @@
     {{ end }}
 
     <ul class="navbar navbar-nav">
-        <li class="nav-item active">
+        <li class="nav-item-explore active">
           <button class="button navbar-button"><a href="https://www.nginx.com/products/" alt="Explore all products on nginx.com" target="_blank">Explore All Products</a></button>
         </li>     
     </ul>


### PR DESCRIPTION
### Proposed changes

Remove border in the top right Explore button,  introduced accidentally while updating tabs CSS.
![image](https://github.com/nginxinc/nginx-hugo-theme/assets/78599298/cfd3ba35-dcc7-449b-b8a5-e7b2e85d27a8)


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
