### PR TITLE
Replace hardcoded Coveo api keys with  a call to Netlify function

### DIFF
--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -1,6 +1,15 @@
 import * as params from '@params';
 document.addEventListener('DOMContentLoaded', function () {
-    Coveo.SearchEndpoint.configureCloudV2Endpoint("", params.coveokey);
+
+    // call our Netlify function via API to get the coveo search key
+    async function getSearchToken() {
+      const response = await fetch(
+        "/netlify/functions/search_token"
+      );
+      const {coveokey} = await response.json();
+    }
+
+    Coveo.SearchEndpoint.configureCloudV2Endpoint("", coveokey);
     const root = document.getElementById("search");
     const searchBoxRoot = document.getElementById("searchbox");
     Coveo.initSearchbox(searchBoxRoot, "/search.html");

--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     // Netlify function to get the coveo search token via API
     async function getSearchToken() {
       const response = await fetch(
-        ".netlify/functions/search_token"
+        process.env.DEPLOY_URL+"/.netlify/functions/search_token"
       );
       return response.json();
     }

--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     }
 
     const searchToken = await getSearchToken()
-    Coveo.SearchEndpoint.configureCloudV2Endpoint("", searchToken);
+    Coveo.SearchEndpoint.configureCloudV2Endpoint("", searchToken.token);
 
     const root = document.getElementById("search");
     const searchBoxRoot = document.getElementById("searchbox");

--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -4,7 +4,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // call our Netlify function via API to get the coveo search key
     async function getSearchToken() {
       const response = await fetch(
-        "/netlify/functions/search_token"
+        "netlify/functions/search_token"
       );
       return await response.json();
     }

--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -2,14 +2,14 @@ import * as params from '@params';
 document.addEventListener('DOMContentLoaded', function () {
 
     // call our Netlify function via API to get the coveo search key
-    async function getSearchToken() {
+    (async function getSearchToken() {
       const response = await fetch(
         "/netlify/functions/search_token"
       );
       const {coveokey} = await response.json();
-    }
+    })()
 
-    Coveo.SearchEndpoint.configureCloudV2Endpoint("", getSearchToken());
+    Coveo.SearchEndpoint.configureCloudV2Endpoint("", coveokey);
     const root = document.getElementById("search");
     const searchBoxRoot = document.getElementById("searchbox");
     Coveo.initSearchbox(searchBoxRoot, "/search.html");

--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -2,14 +2,14 @@ import * as params from '@params';
 document.addEventListener('DOMContentLoaded', function () {
 
     // call our Netlify function via API to get the coveo search key
-    (async function getSearchToken() {
+    async function getSearchToken() {
       const response = await fetch(
         "/netlify/functions/search_token"
       );
-      const {coveokey} = await response.json();
-    })()
+      return await response.json();
+    }
 
-    Coveo.SearchEndpoint.configureCloudV2Endpoint("", coveokey);
+    Coveo.SearchEndpoint.configureCloudV2Endpoint("", getSearchToken());
     const root = document.getElementById("search");
     const searchBoxRoot = document.getElementById("searchbox");
     Coveo.initSearchbox(searchBoxRoot, "/search.html");

--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     // Netlify function to get the coveo search token via API
     async function getSearchToken() {
       const response = await fetch(
-        process.env.DEPLOY_URL+"/.netlify/functions/search_token"
+        window.location.origin+"/.netlify/functions/search_token"
       );
       return response.json();
     }

--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -1,15 +1,17 @@
-import * as params from '@params';
-document.addEventListener('DOMContentLoaded', function () {
+document.addEventListener('DOMContentLoaded', async function () {
 
-    // call our Netlify function via API to get the coveo search key
+    // Netlify function to get the coveo search token via API
     async function getSearchToken() {
       const response = await fetch(
         "netlify/functions/search_token"
       );
-      return await response.json();
+
+      return response.json();
     }
 
-    Coveo.SearchEndpoint.configureCloudV2Endpoint("", getSearchToken());
+    const searchToken = await getSearchToken()
+    Coveo.SearchEndpoint.configureCloudV2Endpoint("", searchToken);
+
     const root = document.getElementById("search");
     const searchBoxRoot = document.getElementById("searchbox");
     Coveo.initSearchbox(searchBoxRoot, "/search.html");

--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -3,9 +3,8 @@ document.addEventListener('DOMContentLoaded', async function () {
     // Netlify function to get the coveo search token via API
     async function getSearchToken() {
       const response = await fetch(
-        "netlify/functions/search_token"
+        ".netlify/functions/search_token"
       );
-
       return response.json();
     }
 

--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', function () {
       const {coveokey} = await response.json();
     }
 
-    Coveo.SearchEndpoint.configureCloudV2Endpoint("", coveokey);
+    Coveo.SearchEndpoint.configureCloudV2Endpoint("", getSearchToken());
     const root = document.getElementById("search");
     const searchBoxRoot = document.getElementById("searchbox");
     Coveo.initSearchbox(searchBoxRoot, "/search.html");

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -23,10 +23,10 @@
 <!-- build a different coveo.js (with different key) based on build env -->
 {{ $.Scratch.Set "coveoSc" "" }}
 {{ if eq hugo.Environment "production" }}
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_API_PROD" }} )) -}}  
+  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_API_PROD" }} )) -}}
   {{ $.Scratch.Set "coveoSc" $coveo}}
 {{ else if eq hugo.Environment "staging" }}
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_API_STAGING" }} )) -}}  
+  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_API_STAGING" }} )) -}}
   {{ $.Scratch.Set "coveoSc" $coveo}} 
 {{ else }}
   {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_API_DEV" }})) -}}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -20,7 +20,7 @@
 
 <script src="https://static.cloud.coveo.com/searchui/v2.10104/0/js/templates/templates.js" integrity="sha512-CR0Yk/LIwgh1MsKqjecDp/r6F9ipKc6gA+4+E1pplT3N3r1pk+la/HaqyDiKtjOFwrwIIbIYBFrUJgPql93QHw==" crossorigin="anonymous"></script>
 
-<!-- build a different coveo.js (with different key) based on build env -->
+<!-- build coveo.js -->
 {{ $.Scratch.Set "coveoSc" "" }}
 {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_SEARCH_TOKEN" }} )) -}}
 {{ $.Scratch.Set "coveoSc" $coveo}}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -21,16 +21,18 @@
 <script src="https://static.cloud.coveo.com/searchui/v2.10104/0/js/templates/templates.js" integrity="sha512-CR0Yk/LIwgh1MsKqjecDp/r6F9ipKc6gA+4+E1pplT3N3r1pk+la/HaqyDiKtjOFwrwIIbIYBFrUJgPql93QHw==" crossorigin="anonymous"></script>
 
 <!-- build a different coveo.js (with different key) based on build env -->
-
 {{ $.Scratch.Set "coveoSc" "" }}
 {{ if eq hugo.Environment "production" }}
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" "xx3b887403-1ec2-43cf-9e3c-d6dd3c1056c0" )) -}}  
+  <!-- {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" "xx3b887403-1ec2-43cf-9e3c-d6dd3c1056c0" )) -}}   -->
+  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_PROD" }} )) -}}  
   {{ $.Scratch.Set "coveoSc" $coveo}}
 {{ else if eq hugo.Environment "staging" }}
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" "xxababbbee-d1e5-44e7-8e49-876ece453e60" )) -}}  
+  <!-- {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" "xxababbbee-d1e5-44e7-8e49-876ece453e60" )) -}}   -->
+  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_STAGING" }} )) -}}  
   {{ $.Scratch.Set "coveoSc" $coveo}} 
 {{ else }}
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" "xx6bbcd723-fec1-4af0-a13d-1c499cf5a15f" )) -}}  
+  <!-- {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" "xx6bbcd723-fec1-4af0-a13d-1c499cf5a15f" )) -}}   -->
+  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_DEV" }})) -}}
   {{ $.Scratch.Set "coveoSc" $coveo}}
 {{ end }}
 {{ $secureCoveo := $.Scratch.Get "coveoSc" | minify | fingerprint "sha512" }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -23,16 +23,13 @@
 <!-- build a different coveo.js (with different key) based on build env -->
 {{ $.Scratch.Set "coveoSc" "" }}
 {{ if eq hugo.Environment "production" }}
-  <!-- {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" "xx3b887403-1ec2-43cf-9e3c-d6dd3c1056c0" )) -}}   -->
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_PROD" }} )) -}}  
+  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_API_PROD" }} )) -}}  
   {{ $.Scratch.Set "coveoSc" $coveo}}
 {{ else if eq hugo.Environment "staging" }}
-  <!-- {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" "xxababbbee-d1e5-44e7-8e49-876ece453e60" )) -}}   -->
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_STAGING" }} )) -}}  
+  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_API_STAGING" }} )) -}}  
   {{ $.Scratch.Set "coveoSc" $coveo}} 
 {{ else }}
-  <!-- {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" "xx6bbcd723-fec1-4af0-a13d-1c499cf5a15f" )) -}}   -->
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_DEV" }})) -}}
+  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_API_DEV" }})) -}}
   {{ $.Scratch.Set "coveoSc" $coveo}}
 {{ end }}
 {{ $secureCoveo := $.Scratch.Get "coveoSc" | minify | fingerprint "sha512" }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -22,7 +22,7 @@
 
 <!-- build coveo.js -->
 {{ $.Scratch.Set "coveoSc" "" }}
-{{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_SEARCH_TOKEN" }} )) -}}
+{{- $coveo := resources.Get "js/coveo.js" | js.Build -}}
 {{ $.Scratch.Set "coveoSc" $coveo}}
 {{ $secureCoveo := $.Scratch.Get "coveoSc" | minify | fingerprint "sha512" }}
 

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -22,16 +22,6 @@
 
 <!-- build a different coveo.js (with different key) based on build env -->
 {{ $.Scratch.Set "coveoSc" "" }}
-<!-- {{ if eq hugo.Environment "production" }}
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_SEARCH_TOKEN" }} )) -}}
-  {{ $.Scratch.Set "coveoSc" $coveo}}
-{{ else if eq hugo.Environment "staging" }}
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_SEARCH_TOKEN" }} )) -}}
-  {{ $.Scratch.Set "coveoSc" $coveo}} 
-{{ else }}
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_SEARCH_TOKEN" }} )) -}}
-  {{ $.Scratch.Set "coveoSc" $coveo}}
-{{ end }} -->
 {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_SEARCH_TOKEN" }} )) -}}
 {{ $.Scratch.Set "coveoSc" $coveo}}
 {{ $secureCoveo := $.Scratch.Get "coveoSc" | minify | fingerprint "sha512" }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -22,16 +22,18 @@
 
 <!-- build a different coveo.js (with different key) based on build env -->
 {{ $.Scratch.Set "coveoSc" "" }}
-{{ if eq hugo.Environment "production" }}
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_API_PROD" }} )) -}}
+<!-- {{ if eq hugo.Environment "production" }}
+  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_SEARCH_TOKEN" }} )) -}}
   {{ $.Scratch.Set "coveoSc" $coveo}}
 {{ else if eq hugo.Environment "staging" }}
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_API_STAGING" }} )) -}}
+  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_SEARCH_TOKEN" }} )) -}}
   {{ $.Scratch.Set "coveoSc" $coveo}} 
 {{ else }}
-  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_API_DEV" }})) -}}
+  {{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_SEARCH_TOKEN" }} )) -}}
   {{ $.Scratch.Set "coveoSc" $coveo}}
-{{ end }}
+{{ end }} -->
+{{- $coveo := resources.Get "js/coveo.js" | js.Build ( dict "params" ( dict "coveokey" {{ getenv "COVEO_SEARCH_TOKEN" }} )) -}}
+{{ $.Scratch.Set "coveoSc" $coveo}}
 {{ $secureCoveo := $.Scratch.Get "coveoSc" | minify | fingerprint "sha512" }}
 
 


### PR DESCRIPTION
### Proposed changes

Previously the values of each Coveo API key were hardcoded into the hugo theme code in `layouts/partial/scripts.html` which would pass the appropriate key value to the `js.Build` command. This would result in the api key being embedded in the minified javascript code, and observable via the inspection tools in a web browser.

This change removes those hardcoded values and replaces them with an API call to a Netlify function which will return the value of the `COVEO_SEARCH_TOKEN` variable from the Netlify site's environment variables.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
