### PR TITLE
fix: remove return carriage from copied text

### DIFF
--- a/assets/js/code-copy.js
+++ b/assets/js/code-copy.js
@@ -6,7 +6,8 @@ function CopyCode(clipboard) {
         button.innerHTML = '<i class="fas fa-copy"></i> Copy';
 
         button.addEventListener('click', function() {
-            clipboard.writeText(codeBlock.textContent).then(
+            // removes return carriage from copied text
+            clipboard.writeText(codeBlock.textContent.replace(/\n$/g, "")).then(
                 function() {
                     button.blur(); /* Chrome fix */
                     button.innerHTML = '<i class="fas fa-check"></i> Copied!';


### PR DESCRIPTION
### Proposed changes
bugfix for docs-386
Remove return carriage from copied text as it causes code pasted into a terminal to execute automatically.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
