### PR TITLE
fix: order for list pages + navbar improv

### DIFF
--- a/assets/js/sidebar.js
+++ b/assets/js/sidebar.js
@@ -4,12 +4,31 @@ $(document).ready(function () {
         if (item.dataset.menuId == $(".main").data("menuId")) {
             $(item).css("color", "#429345");
             $(item).css("font-weight", "500");
+
+            // Remove "collapsed" class and set aria-expanded to "true" for the current item
+            $(item).removeClass("collapsed");
+            $(item).attr("aria-expanded", "true");
+            
+            // Capture data-target value
+            var targetId = $(item).data("target");
+            if (!targetId) {
+                var hrefValue = $(item).attr("href");
+                // Add "show" class to the corresponding divs with matching id
+                var targetDivs = $("div[id='" + hrefValue.replace("#", "") + "']");
+                targetDivs.addClass("show");
+            } else {
+                $(targetId).addClass("show");
+            }
+            
+            // Expand parents
             $(item).parents(".collapse").each(function(i,el) {
                 var col = new bootstrap.Collapse(el, {
                     toggle: false
                 });
                 col.show();
             });
-      }
-      });
+
+            $(item).next(".accordion-body").find(".collapse").addClass("show");
+        }
+        });
 });

--- a/layouts/partials/list-main.html
+++ b/layouts/partials/list-main.html
@@ -5,75 +5,43 @@
                 {{ .Title }}
             </h1>
             {{ if .Description }}
-                <p class="bd-lead">
+                <p>
                     {{ .Description | markdownify }}
                 </p>
             {{ end}}
             {{ if .Content }}
-                <p class="bd-lead">
+                <p>
                     {{ .Content | markdownify }}
                 </p>
             {{ end }}
         </div>
     </div>
 
-    <section class="col-md-12 col-xl-12 py-md-3 pl-md-5" id="section-content-list">
-        
+    <section>
         <div class="row">
             <div class="card-deck">
-            {{ if .Sections }}
-                {{ range .Sections }}
-                <div class="col-md-5 card">
-                    <div class="card-body">
-                        <h3 class="card-title">
-                            <i class="fas fa-{{if .Page.Params.icon}}{{ .Page.Params.icon }}{{else}}book{{end}} fa-2x card-img-top"></i>
-                            <a href="{{ .Permalink }}">{{ .Title }}</a>
-                        </h3>
-                        {{/*}}<p class="card-text">
-                            {{ if .Description }}{{ .Description | markdownify }}{{ end }}
-                        </p>{{*/}}
-                        {{ if and (eq .Site.Params.useSectionPageLists "true") (.Pages) }}
-                        <ul class="card-list">
-                            {{ range first 5 .Pages.ByWeight }}
-                            <li>
-                                <a href="{{ .Permalink }}">{{ .Title }}</a>
-                            </li>
-                            {{ end }}
-                            {{ if gt .Pages "5" }}
-                            <li>
-                                <a href="{{ .Permalink }}">More...</a>
-                            </li>
-                            {{ end }}
-                        </ul>
-                        {{ end }}
-                    </div>
-                </div>
-                {{ end }}
-            {{ end }}
+        {{ range .Pages.GroupBy "Section" }}
             
-            {{ range (.Paginate ( where .Pages.ByWeight ".Kind" "!=" "section" )).Pages }}
-                <div class="col-md-5 card">
-                    <div class="card-body">
-                        <h3 class="card-title">
-                            <i class="far fa-{{if .Page.Params.icon}}{{ .Page.Params.icon }}{{else}}file-alt{{end}} fa-2x card-img-top"></i>
-                            <a href="{{ .Permalink }}">{{ .Title }}</a>
-                        </h3>
-                        {{/*}}
-                        <p class="card-text">
-                            {{ if .Description }} {{ .Description | markdownify }}{{ end }}
-                        </p>{{*/}}
-                    </div>
-                </div>
-            {{ end }}        
-          </div>
-        </div>
+            {{ range .Pages.ByWeight }}
+            <div class="col-md-5 card">
+                <div class="card-body">
+                    <h3 class="card-title">
+                        <i class="fas fa-{{if eq .Kind "page"}}file-alt{{else}}book{{end}} fa-2x card-img-top"></i>
+                        <a href="{{ if .Params.url}}{{ .Params.url}}{{else}}{{ .Permalink }}{{end}}">{{ .Title }}</a>
+                    </h3>
+                    {{/*}}<p class="card-text">
+                        {{ if .Description }}{{ .Description | markdownify }}{{ end }}    
+                    </p>{{*/}}
+            
+            </div>
+            </div>
+
+            {{ end }}
+        </div> 
+    </div>  
+        {{ end }}
+
+
     </section>
-
-    {{ if not .IsHome }}
-    <div class="row justify-content-center">
-        {{ partial "pagination.html" . }}
-    </div>
-    {{ end }}
-
     
 </div>


### PR DESCRIPTION
### Proposed changes

Imports the list-main.html changes from the docs repo to the theme

- This change makes items in the list pages appear in the same order as they appear in the side navigation

Improves the navigation bar:

- When browsing a section list-page the navigation will highlight the section and (new) expand it to show the same subsections as the list page is showing:

before:

![image](https://github.com/nginxinc/nginx-hugo-theme/assets/78599298/af14ebbc-296f-4bf6-95c8-ffcbd93451fc)


after:

![image](https://github.com/nginxinc/nginx-hugo-theme/assets/78599298/f1b94f3f-204f-4d8f-85e0-7e1f766505fc)


Closes DOC-146

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
