### PR TITLE
fix: fix landing page rendering with weight order

### DIFF
--- a/layouts/partials/list-main.html
+++ b/layouts/partials/list-main.html
@@ -5,43 +5,46 @@
                 {{ .Title }}
             </h1>
             {{ if .Description }}
-                <p>
+                <p class="bd-lead">
                     {{ .Description | markdownify }}
                 </p>
             {{ end}}
             {{ if .Content }}
-                <p>
+                <p class="bd-lead">
                     {{ .Content | markdownify }}
                 </p>
             {{ end }}
         </div>
     </div>
 
-    <section>
+    <section class="col-md-12 col-xl-12 py-md-3 pl-md-5" id="section-content-list">
+        
         <div class="row">
-            <div class="card-deck">
-        {{ range .Pages.GroupBy "Section" }}
-            
-            {{ range .Pages.ByWeight }}
-            <div class="col-md-5 card">
-                <div class="card-body">
-                    <h3 class="card-title">
-                        <i class="fas fa-{{if eq .Kind "page"}}file-alt{{else}}book{{end}} fa-2x card-img-top"></i>
-                        <a href="{{ if .Params.url}}{{ .Params.url}}{{else}}{{ .Permalink }}{{end}}">{{ .Title }}</a>
-                    </h3>
-                    {{/*}}<p class="card-text">
-                        {{ if .Description }}{{ .Description | markdownify }}{{ end }}    
-                    </p>{{*/}}
-            
-            </div>
-            </div>
-
-            {{ end }}
+            <div class="card-deck">            
+                {{ range .Pages.ByWeight }}
+                <div class="col-md-5 card">
+                    <div class="card-body">
+                        <h3 class="card-title">
+                            <i class="fas fa-{{if eq .Kind "page"}}file-alt{{else}}book{{end}} fa-2x card-img-top"></i>
+                            <a href="{{ if .Params.url}}{{ .Params.url}}{{else}}{{ .Permalink }}{{end}}">{{ .Title }}</a>
+                        </h3>
+                        {{/*}}<p class="card-text">
+                            {{ if .Description }}{{ .Description | markdownify }}{{ end }}    
+                        </p>{{*/}}
+                    </div>
+                </div>
+                {{ end }}
+            </div> 
         </div> 
-    </div>  
-        {{ end }}
-
-
     </section>
+</div>
+
+
+    {{ if not .IsHome }}
+    <div class="row justify-content-center">
+        {{ partial "pagination.html" . }}
+    </div>
+    {{ end }}
+
     
 </div>


### PR DESCRIPTION
### Proposed changes

List pages will respect weights to order the items (sections and pages)

Uses part of the code from the docs repo for the same solution. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
