### PR TITLE
fix: revert un-needed css changes

### DIFF
--- a/assets/css/docs-nginx-com/style.css
+++ b/assets/css/docs-nginx-com/style.css
@@ -161,7 +161,7 @@ sup {
     font-weight: inherit
 }
 html {
-    scroll-behavior: auto;
+    scroll-behavior: smooth;
     font-size: 62.5%;
     overflow-y: scroll;
     -webkit-text-size-adjust: 100%;


### PR DESCRIPTION
### Proposed changes

Reverts the change in 0.40.8 which is not required any more, as Redoc has been fixed in the layout.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
