### PR TITLE
Feat: add details element shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This theme contains the following custom shorcodes:
 **Formatting**:
 
 - collapse.html - Make a collapsible section.
+- details-disclosure.html - Renders information inside a toggleable element (open by default but can be toggled in/out of visibility).
 - comment.html - Insert a comment that won't be rendered at build time.
 - raw-html.html - Insert raw HTML into a markdown doc.
 

--- a/layouts/shortcodes/details-disclosure.html
+++ b/layouts/shortcodes/details-disclosure.html
@@ -1,0 +1,5 @@
+{{ $summary := .Get "summary"}} 
+<details open>
+    <summary>{{ $summary }}</summary>
+    {{ .Inner | markdownify }}
+</details>


### PR DESCRIPTION
### Proposed changes

Create a shortcode for the [details HTML element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) that is used throughout many of the documentation sites. Currently these cases just use the html inside of the markdown pages and this shortcode will remove the need for the markdown to contain this html content.

### Checklist

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
