### PR TITLE
Allow dropdown to be in the closed state initially

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This theme contains the following custom shorcodes:
 **Formatting**:
 
 - collapse.html - Make a collapsible section.
+- details-disclosure.html - Renders information inside a toggleable element (open by default but can be toggled in/out of visibility).
 - comment.html - Insert a comment that won't be rendered at build time.
 - raw-html.html - Insert raw HTML into a markdown doc.
 

--- a/layouts/shortcodes/details-disclosure.html
+++ b/layouts/shortcodes/details-disclosure.html
@@ -1,5 +1,9 @@
 {{ $summary := .Get "summary"}} 
-<details open>
+{{ $initial_state := .Get "initial_state"}} 
+
+<details {{ $initial_state }}>
     <summary>{{ $summary }}</summary>
+    
     {{ .Inner | markdownify }}
+
 </details>

--- a/layouts/shortcodes/details-disclosure.html
+++ b/layouts/shortcodes/details-disclosure.html
@@ -1,0 +1,5 @@
+{{ $summary := .Get "summary"}} 
+<details open>
+    <summary>{{ $summary }}</summary>
+    {{ .Inner | markdownify }}
+</details>


### PR DESCRIPTION
### Proposed changes

One [docs](https://github.com/nginxinc/docs) site has the details element in the closed state initially. I have updated this shortcode to allow the element to have the 'open' or 'closed' state attached to it rather than always having the 'open' state.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
