### PR TITLE
chore: add border to md screenshots

### DIFF
--- a/assets/css/docs-nginx-com/style.css
+++ b/assets/css/docs-nginx-com/style.css
@@ -186,20 +186,6 @@ section {
     display: block
 }
 
-.figure-bitmap {
-   border: solid 2px #42932D;
-   margin-bottom: 10px;
-   display: inline-block;
-   max-width: 100%;
-}
-
-.figure-svg {
-   border: solid 2px #42932D;
-   margin-bottom: 10px;
-   display: block;
-   min-width: 100%;
-}
-
 caption,
 td {
     font-weight: 300

--- a/assets/css/f5-hugo.css
+++ b/assets/css/f5-hugo.css
@@ -1540,3 +1540,25 @@ li.nav-item a.nav-link {
   border-top: 1px solid #429345;
   margin-bottom: 10px;
 }
+
+.figure-bitmap {
+   border: solid 2px #42932D;
+   margin-bottom: 10px;
+   display: inline-block;
+   max-width: 100%;
+}
+
+.figure-svg {
+   border: solid 2px #42932D;
+   margin-bottom: 10px;
+   display: block;
+   min-width: 100%;
+}
+
+.md__image {
+  border: solid 2px #42932D;
+  margin-bottom: 10px;
+  display: inline-block;
+  max-width: 100%;
+  min-width: 100%;
+}


### PR DESCRIPTION
### Proposed changes

Adds the CSS border to screenshots not using the img shortcode which are using the markdown notation `![alt](src)`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
