### PR TITLE
fix: make chevrons smaller

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -43,8 +43,8 @@
                                 <a data-menu-id="{{.RelPermalink}}" class="accordion-toggle" aria-expanded="false"
                                     data-toggle="collapse" href="#" data-target="#{{.Section | urlize}}--{{.Title | urlize}}"
                                     aria-controls="{{.Section | urlize}}--{{.Title | urlize}}">
-                                    <i class="fa fa-sm fa-fw fa-chevron-right"></i><i
-                                        class="fa fa-sm fa-fw fa-chevron-down"></i>{{ .Title }}</a>
+                                    <i class="fa fa-2xs fa-fw fa-chevron-right"></i><i
+                                        class="fa fa-2xs fa-fw fa-chevron-down"></i>{{ .Title }}</a>
                             </li>
                         </div>
                         <div id="{{.Section | urlize}}--{{.Title | urlize}}" class="accordion-body collapse">
@@ -92,7 +92,7 @@
                                                         <li class="nginx-toc-link l3 sidebar-il-border">
                                                             <a data-menu-id="{{.RelPermalink}}" href="{{ .Permalink }}">{{ .Title }}</a>
                                                         </li>
-                                                    </ul>                                            
+                                                    </ul>
                                                     <!-- Create an accordion group for Level 3 sections -->
                                                     {{else}}
                                                     <div class="accordion" id="Accordion3">
@@ -148,7 +148,7 @@
                                                                                                 </li>
                                                                                             </ul>
                                                                                             <!-- Create an accordion group for Level 5sections -->
-                                                                                            {{else}}    
+                                                                                            {{else}}
                                                                                             <div class="accordion" id="Accordion5">
                                                                                                 <div class="sidebar-l2-padding">
                                                                                                     <div class="accordion-group sidebar-il-border">
@@ -174,14 +174,14 @@
                                                                             </div>
                                                                         </div>
                                                                         {{ end }}
-                                                                        {{ end }}  
+                                                                        {{ end }}
                                                                     </div>
                                                                 </div>
                                                             </div>
                                                         </div>
                                                     </div>
                                                     {{ end }}
-                                                {{ end }}                                        
+                                                {{ end }}
                                                 </div>
                                             </div>
                                         </div>
@@ -192,7 +192,7 @@
                             </div>
                         </div>
                     </div>
-                </div> 
+                </div>
                 {{ end }}
             {{ end }}
         {{ end }}


### PR DESCRIPTION
### Proposed changes

This PR makes the chevrons in the navigation bar smaller (same as the docs repo)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
