### PR TITLE
Feat: add icon prefix option to disclosure shortcode

### DIFF
--- a/layouts/shortcodes/details-disclosure.html
+++ b/layouts/shortcodes/details-disclosure.html
@@ -1,8 +1,9 @@
 {{ $summary := .Get "summary"}} 
 {{ $initial_state := .Get "initial_state"}} 
+{{ $icon := .Get "icon"}}
 
 <details {{ $initial_state }}>
-    <summary>{{ $summary }}</summary>
+    <summary>{{ if .Get "icon_prefix" }}<i class="{{ $icon }}"></i>&nbsp;{{ end }}{{ $summary }}</summary>
     
     {{ .Inner | markdownify }}
 


### PR DESCRIPTION
### Proposed changes

Instances of details/summary blocks on the docs site include icons in the summaries (e.g., fa-file). The details shortcode did not have any option for adding icons. This PR introduces two new params:

- a boolean on whether to include an icon prefix or not
- the icon string to be used in the &lt;i&gt; class

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
