### PR TITLE
Add custom table of contents partial for use with catalog

### DIFF
--- a/layouts/partials/catalog-toc.html
+++ b/layouts/partials/catalog-toc.html
@@ -1,0 +1,16 @@
+{{/*  Parse param from front matter  */}}
+{{ $dataPath := split .Params.catalogType "." }}
+{{ $data := .Site.Data }}
+{{range $dataPath}}
+    {{ $data =  index $data . }}
+{{ end }}
+<nav id="TableOfContents">
+    <ul>
+        {{ range $data }}
+        {{/*  Render catalog toc list  */}}
+        <li>
+            <a href="#{{.name}}">{{.name}}</a>
+        </li>
+        {{ end }}
+    </ul>
+</nav>

--- a/layouts/partials/toc.html
+++ b/layouts/partials/toc.html
@@ -1,18 +1,12 @@
 <nav class="bd-links" aria-label="Main navigation">
-
   <div class="bd-toc-item active">
-    
     <h3 class="bd-toc-link">What's on This Page</h3>
-
-    {{ with .TableOfContents }}
-  
-      {{ . }}
-    
+    {{ if .Params.catalogType }}
+      {{ partial "catalog-toc" . }}  
+    {{ else }}
+      {{ with .TableOfContents }}
+        {{ . }}
+      {{ end }}
     {{ end }}
-  
   </div>
 </nav>
-
-
-
-


### PR DESCRIPTION
### Proposed changes

Fix for https://github.com/nginxinc/nginx-hugo-theme/issues/61

Adds a custom table of contents. You can now include a `catalogType` when `toc` is true. The catalogType will be used to render the content of `.Site.Data.${catalogType}` as a list.

For example

``` md
toc: true
catalogType: nms.catalogs.events
```



### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
