### PR TITLE
change search_token endpoint to non netlify path

### DIFF
--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', async function () {
     // Netlify function to get the coveo search token via API
     async function getSearchToken() {
       const response = await fetch(
-        window.location.origin+"/.netlify/functions/search_token"
+        window.location.origin+"/api/v1/auth/search_token"
       );
       return response.json();
     }


### PR DESCRIPTION
This update the `search_token` endpoint to be `/api/v1/auth/search_token`.
The reasons for this are;
- Moving away from any netlify references
- Forcing a new endpoint will break the token stale cache issue
- Moving to a "versioned" endpoint will make for cleaner update going forward