### PR TITLE
fix: replace .Site.BaseURL with absURL in templates

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -9,17 +9,17 @@
       <div class="col-md-4">
       </div>
       <div class="card-body">
-        
+
         <div class="card-text">
-        <p>Uh oh! We couldn't find the page you were looking for.</p> 
-        <p><a class="button button-solid" href="{{.Site.BaseURL}}">Return to the NGINX Docs Home page.</a></p>
+        <p>Uh oh! We couldn't find the page you were looking for.</p>
+        <p><a class="button button-solid" href="{{ "/" | absURL }}">Return to the NGINX Docs Home page.</a></p>
       </div>
-    </div>  
+    </div>
   </div>
 </div>
 </div>
 
-  
+
 
 
 {{ end }}

--- a/layouts/partials/favicon.html
+++ b/layouts/partials/favicon.html
@@ -1,1 +1,1 @@
-<link rel="shortcut icon" type="image/x-icon" href="{{.Site.BaseURL}}/images/favicon-48x48.ico">
+<link rel="shortcut icon" type="image/x-icon" href="{{ "/images/favicon-48x48.ico" | absURL }}">

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,89 +1,89 @@
 <footer id="footer">
-    <div class="container-fluid">
+   <div class="container-fluid">
 
-        <div class="row align-items-center">
+       <div class="row align-items-center">
 
-          <div class="col-md-6 d-md-flex">
-              <img class="nginx-logo-footer" src="{{.Site.BaseURL}}/images/icons/NGINX-Part-of-F5-horiz-all-white-525x208@2x.png"/>
-          </div>
+         <div class="col-md-6 d-md-flex">
+             <img class="nginx-logo-footer" src="{{ "/images/icons/NGINX-Part-of-F5-horiz-all-white-525x208@2x.png" | absURL }}"/>
+         </div>
 
-          {{ if not ( in .Site.Params.buildtype "package" ) }}
-          <div class="col-md d-flex footer-text">
-            <div class="col-xl d-none d-md-block align-self-center text-semibold align-right">
-              <span>Found a bug? Looking for something new?</span>
-            </div>
-            <div class="col-lg d-none d-md-block pl-0">
-              <button class="button footer-button"><a href="/feedback/" alt="Select if you have feedback">Let Us Know</a></button>
-            </div>
-          </div>
-          {{ end }}
+         {{ if not ( in .Site.Params.buildtype "package" ) }}
+         <div class="col-md d-flex footer-text">
+           <div class="col-xl d-none d-md-block align-self-center text-semibold align-right">
+             <span>Found a bug? Looking for something new?</span>
+           </div>
+           <div class="col-lg d-none d-md-block pl-0">
+             <button class="button footer-button"><a href="{{ "/feedback/" | absURL }}" alt="Select if you have feedback">Let Us Know</a></button>
+           </div>
+         </div>
+         {{ end }}
 
-        </div>
+       </div>
 
 
-        {{ if not ( in .Site.Params.buildtype "package" ) }}
-        <div class="row d-print-none d-none d-md-flex">
-          <div class="col-md-3 d-none d-md-block">
-            <span class="footer-head">Company</span>
-            <ul class="footer-text">
-              <li><a href="https://www.f5.com/go/product/welcome-to-nginx" target="_blank" alt="Select to learn about F5 NGINX">About F5 NGINX</a></li>
-              <li><a href="https://www.f5.com/company/events" target="_blank" alt="Select to learn about F5 events">Events</a></li>
-            </ul>
-            <br />
-            <span class="footer-head">Resources</span>
-            <ul class="footer-text">
-              <li><a href="https://www.f5.com/company/blog/nginx" target="_blank" alt="Select to visit the F5 NGINX blog" >Blog</a></li>
-              <li><a href="https://www.f5.com/go/faq/nginx-faq" target="_blank" alt="Select to visit the F5 NGINX frequently asked questions page" >FAQ</a></li>
-              <li><a href="https://www.f5.com/services" target="_blank" alt="Select to learn about F5 NGINX Support">Professional Services</a></li>
-              <li><a href="https://www.f5.com/learn/training" target="_blank" alt="Select to learn about F5 training offerings" >Training</a></li>
-            </ul>
-          </div>
+       {{ if not ( in .Site.Params.buildtype "package" ) }}
+       <div class="row d-print-none d-none d-md-flex">
+         <div class="col-md-3 d-none d-md-block">
+           <span class="footer-head">Company</span>
+           <ul class="footer-text">
+             <li><a href="https://www.f5.com/go/product/welcome-to-nginx" target="_blank" alt="Select to learn about F5 NGINX">About F5 NGINX</a></li>
+             <li><a href="https://www.f5.com/company/events" target="_blank" alt="Select to learn about F5 events">Events</a></li>
+           </ul>
+           <br />
+           <span class="footer-head">Resources</span>
+           <ul class="footer-text">
+             <li><a href="https://www.f5.com/company/blog/nginx" target="_blank" alt="Select to visit the F5 NGINX blog" >Blog</a></li>
+             <li><a href="https://www.f5.com/go/faq/nginx-faq" target="_blank" alt="Select to visit the F5 NGINX frequently asked questions page" >FAQ</a></li>
+             <li><a href="https://www.f5.com/services" target="_blank" alt="Select to learn about F5 NGINX Support">Professional Services</a></li>
+             <li><a href="https://www.f5.com/learn/training" target="_blank" alt="Select to learn about F5 training offerings" >Training</a></li>
+           </ul>
+         </div>
 
-          <div class="col-md-3 d-none d-md-block">
-            <span class="footer-head">Products</span>
-              <ul class="footer-text">
-                  <li><a title="F5 NGINX Plus" aria-label="F5 NGINX Plus" href="https://www.f5.com/products/nginx/nginx-plus">F5 NGINX Plus</a></li>
-                  <li><a title="F5 NGINX App Protect" aria-label="F5 NGINX App Protect" href="https://www.f5.com/products/nginx/nginx-app-protect">F5 NGINX App Protect</a></li>
-                  <li><a title="F5 NGINX Instance Manager" aria-label="F5 NGINX Instance Manager" href="https://www.f5.com/products/nginx/instance-manager">F5 NGINX Instance Manager</a></li>
-                  <li><a title="F5 NGINX Ingress Controller" aria-label="F5 NGINX Ingress Controller" href="https://www.f5.com/products/nginx/nginx-ingress-controller">F5 NGINX Ingress Controller</a></li>
-                  <li><a title="F5 NGINX Gateway Fabric" aria-label="F5 NGINX Gateway Fabric" href="https://www.f5.com/products/nginx/nginx-gateway-fabric">F5 NGINX Gateway Fabric</a></li>
-                  <li><a title="F5 NGINXaaS for Azure" aria-label="F5 NGINXaaS for Azure" href="https://www.f5.com/products/nginx/f5-nginxaas-for-azure">F5 NGINXaaS for Azure</a></li>
-              </ul>
-          </div>
+         <div class="col-md-3 d-none d-md-block">
+           <span class="footer-head">Products</span>
+             <ul class="footer-text">
+                 <li><a title="F5 NGINX Plus" aria-label="F5 NGINX Plus" href="https://www.f5.com/products/nginx/nginx-plus">F5 NGINX Plus</a></li>
+                 <li><a title="F5 NGINX App Protect" aria-label="F5 NGINX App Protect" href="https://www.f5.com/products/nginx/nginx-app-protect">F5 NGINX App Protect</a></li>
+                 <li><a title="F5 NGINX Instance Manager" aria-label="F5 NGINX Instance Manager" href="https://www.f5.com/products/nginx/instance-manager">F5 NGINX Instance Manager</a></li>
+                 <li><a title="F5 NGINX Ingress Controller" aria-label="F5 NGINX Ingress Controller" href="https://www.f5.com/products/nginx/nginx-ingress-controller">F5 NGINX Ingress Controller</a></li>
+                 <li><a title="F5 NGINX Gateway Fabric" aria-label="F5 NGINX Gateway Fabric" href="https://www.f5.com/products/nginx/nginx-gateway-fabric">F5 NGINX Gateway Fabric</a></li>
+                 <li><a title="F5 NGINXaaS for Azure" aria-label="F5 NGINXaaS for Azure" href="https://www.f5.com/products/nginx/f5-nginxaas-for-azure">F5 NGINXaaS for Azure</a></li>
+             </ul>
+         </div>
 
-          <div class="col-md-3 d-none d-md-block">
-            <span class="footer-head">NGINX on GitHub</span>
-            <ul class="footer-text">
-              <li><a title="NGINX Open Source" aria-label="NGINX Open Source" href="https://github.com/nginx/nginx"><span class="inner">NGINX Open Source</span></a></li>
-              <li><a title="NGINX Unit" aria-label="NGINX Unit" href="https://github.com/nginx/unit"><span class="inner">NGINX Unit</span></a></li>
-              <li><a title="NGINX Amplify" aria-label="NGINX Amplify" href="https://github.com/nginxinc/nginx-amplify-agent"><span class="inner">NGINX Amplify</span></a></li>
-              <li><a title="NGINX Agent" aria-label="NGINX Agent" href="https://github.com/nginx/Agent"><span class="inner">NGINX Agent</span></a></li>
-              <li><a title="NGINX Kubernetes Ingress Controller" aria-label="NGINX Kubernetes Ingress Controller" href="https://github.com/nginxinc/kubernetes-ingress"><span class="inner">NGINX Kubernetes Ingress Controller</span></a></li>
-              <li><a title="NGINX Gateway Fabric" aria-label="NGINX Gateway Fabric" href="https://github.com/nginxinc/nginx-gateway-fabric"><span class="inner">NGINX Gateway Fabric</span></a></li>
-          </ul>
-          </div>
+         <div class="col-md-3 d-none d-md-block">
+           <span class="footer-head">NGINX on GitHub</span>
+           <ul class="footer-text">
+             <li><a title="NGINX Open Source" aria-label="NGINX Open Source" href="https://github.com/nginx/nginx"><span class="inner">NGINX Open Source</span></a></li>
+             <li><a title="NGINX Unit" aria-label="NGINX Unit" href="https://github.com/nginx/unit"><span class="inner">NGINX Unit</span></a></li>
+             <li><a title="NGINX Amplify" aria-label="NGINX Amplify" href="https://github.com/nginxinc/nginx-amplify-agent"><span class="inner">NGINX Amplify</span></a></li>
+             <li><a title="NGINX Agent" aria-label="NGINX Agent" href="https://github.com/nginx/Agent"><span class="inner">NGINX Agent</span></a></li>
+             <li><a title="NGINX Kubernetes Ingress Controller" aria-label="NGINX Kubernetes Ingress Controller" href="https://github.com/nginxinc/kubernetes-ingress"><span class="inner">NGINX Kubernetes Ingress Controller</span></a></li>
+             <li><a title="NGINX Gateway Fabric" aria-label="NGINX Gateway Fabric" href="https://github.com/nginxinc/nginx-gateway-fabric"><span class="inner">NGINX Gateway Fabric</span></a></li>
+         </ul>
+         </div>
 
-          <div class="col-md-2 d-none d-md-block">
-            <span class="footer-head">Social</span>
-                <ul class="footer-social">
-                  <li><a href="https://www.facebook.com/nginxinc" title="facebook" aria-label="facebook" target="_blank" rel="noreferrer"><i class="fa-brands fa-facebook" aria-hidden="true"></i>
-                    Facebook</a></li>
-                  <li><a href="https://twitter.com/nginx" title="twitter" aria-label="twitter" target="_blank" rel="noreferrer"><i class="fa-brands fa-twitter" aria-hidden="true"></i>Twitter</a></li>
-                  <li><a href="https://www.linkedin.com/company/nginx" title="linkedin" aria-label="linkedin" target="_blank" rel="noreferrer"><i class="fa-brands fa-linkedin" aria-hidden="true"></i>
-                    LinkedIn</a></li>
-                  <li><a href="https://www.youtube.com/user/NginxInc" title="youtube" aria-label="youtube" target="_blank" rel="noreferrer" alt="NGINX Youtube Channel"><i class="fa-brands fa-square-youtube" aria-hidden="true"></i>
-                    YouTube</a></li>
-                </ul>
-          </div>
-        </div>
-        {{ end }}
-        <div class="site-info footer-text">
+         <div class="col-md-2 d-none d-md-block">
+           <span class="footer-head">Social</span>
+               <ul class="footer-social">
+                 <li><a href="https://www.facebook.com/nginxinc" title="facebook" aria-label="facebook" target="_blank" rel="noreferrer"><i class="fa-brands fa-facebook" aria-hidden="true"></i>
+                   Facebook</a></li>
+                 <li><a href="https://twitter.com/nginx" title="twitter" aria-label="twitter" target="_blank" rel="noreferrer"><i class="fa-brands fa-twitter" aria-hidden="true"></i>Twitter</a></li>
+                 <li><a href="https://www.linkedin.com/company/nginx" title="linkedin" aria-label="linkedin" target="_blank" rel="noreferrer"><i class="fa-brands fa-linkedin" aria-hidden="true"></i>
+                   LinkedIn</a></li>
+                 <li><a href="https://www.youtube.com/user/NginxInc" title="youtube" aria-label="youtube" target="_blank" rel="noreferrer" alt="NGINX Youtube Channel"><i class="fa-brands fa-square-youtube" aria-hidden="true"></i>
+                   YouTube</a></li>
+               </ul>
+         </div>
+       </div>
+       {{ end }}
+       <div class="site-info footer-text">
 
-            <div class="text-center">
-            <p><a href="https://www.f5.com/"><img class="f5-logo-footer" src="{{.Site.BaseURL}}/images/icons/Logo_F5.svg" alt="F5 logo"></a>
-               ©2024 F5, Inc. All rights reserved.</p><p><a href="https://www.f5.com/company/policies/trademarks" rel="noopener" target="_blank">Trademarks</a>  <a href="https://www.f5.com/company/policies" rel="noopener" target="_blank">Policies</a> <a href="{{ .Site.BaseURL }}/ossc">Open Source Components</a>  <a href="https://www.f5.com/company/policies/privacy-notice" rel="noopener" target="_blank">Privacy</a>  <a href="https://www.f5.com/company/policies/F5-California-privacy-summary" rel="noopener" target="_blank">California Privacy</a>  <a href="https://www.f5.com/company/policies/privacy-notice#no-sell" rel="noopener" target="_blank">Do Not Sell My Personal Information</a>  <span id="teconsent"></span></p>
-            </div>
+           <div class="text-center">
+           <p><a href="https://www.f5.com/"><img class="f5-logo-footer" src="{{ "/images/icons/Logo_F5.svg" | absURL }}" alt="F5 logo"></a>
+              ©2024 F5, Inc. All rights reserved.</p><p><a href="https://www.f5.com/company/policies/trademarks" rel="noopener" target="_blank">Trademarks</a>  <a href="https://www.f5.com/company/policies" rel="noopener" target="_blank">Policies</a> <a href="{{ "/ossc" | absURL }}">Open Source Components</a>  <a href="https://www.f5.com/company/policies/privacy-notice" rel="noopener" target="_blank">Privacy</a>  <a href="https://www.f5.com/company/policies/F5-California-privacy-summary" rel="noopener" target="_blank">California Privacy</a>  <a href="https://www.f5.com/company/policies/privacy-notice#no-sell" rel="noopener" target="_blank">Do Not Sell My Personal Information</a>  <span id="teconsent"></span></p>
+           </div>
 
-        </div><!-- /.site-info -->
-    </div><!-- /.container-fluid -->
+       </div><!-- /.site-info -->
+   </div><!-- /.container-fluid -->
 </footer>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,7 @@
 <div class="navbar navbar-expand navbar-dark flex-column flex-md-row bd-navbar navbar-fixed-top">
   <div class="container-fluid flex-md-row flex-column">
     <a class="navbar-brand mr-0 mr-md-2" href="/" aria-label="NGINX Docs">
-      <img class="navbar-img" src="{{.Site.BaseURL}}/images/icons/NGINX-Docs-horiz-white-type.svg" alt="NGINX Docs">
+      <img class="navbar-img" src="{{ "/images/icons/NGINX-Docs-horiz-white-type.svg" | absURL }}" alt="NGINX Docs">
     </a>
     {{ if ( not ( in .Site.Params.buildtype "package" ) ) }}
       <div class="navbar navbar-nav">
@@ -21,7 +21,7 @@
             Sections
           </a>
           {{ partial "products-menu.html" . }}
-        </li>    
+        </li>
       </ul>
     </div>
     {{ end }}
@@ -29,7 +29,7 @@
     <ul class="navbar navbar-nav">
         <li class="nav-item-explore active">
           <button class="button navbar-button"><a href="https://www.f5.com/products" alt="Explore all products on f5.com" target="_blank">Explore All Products</a></button>
-        </li>     
+        </li>
     </ul>
   </div>
 </div>

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -5,7 +5,7 @@
 <title>{{ block "title" . }}{{ if .IsHome }}{{ .Site.Title }}{{else}}{{ .Title  }}{{end }}{{ if and ( not .IsHome ) ( .Site.Title ) }} | {{ .Site.Title }}{{end}}{{ end }}</title>
 
 {{ with .Description }}
-<meta name="description" content="{{ . | markdownify }}"> 
+<meta name="description" content="{{ . | markdownify }}">
 {{ end }}
 
 {{ if .Params.categories }}
@@ -24,14 +24,14 @@
 {{ end }}
 
 <meta property="article:publisher" content="https://www.facebook.com/nginxinc" />
-<meta property="og:image" content="{{ .Site.BaseURL }}/images/icons/NGINX-Docs-new-docs-dark-1200x630.png" />
+<meta property="og:image" content="{{ "/images/icons/NGINX-Docs-new-docs-dark-1200x630.png" | absURL }}" />
 <meta property="og:image:width" content="500" />
 <meta property="og:image:height" content="300" />
 <meta name="twitter:card" content="summary" />
 <meta name="twitter:description" content="{{.Page.Description}}" />
 <meta name="twitter:title" content="{{.Page.Title}}" />
 <meta name="twitter:site" content="@nginx" />
-<meta name="twitter:image" content="{{ .Site.BaseURL }}/images/icons/NGINX-Docs-new-docs-dark-1200x630.png" />
+<meta name="twitter:image" content="{{ "/images/icons/NGINX-Docs-new-docs-dark-1200x630.png" | absURL }}" />
 <meta name="twitter:creator" content="@nginx" />
 {{ if .Page.Lastmod }}
 <meta http-equiv="last-modified" content="{{ .Page.Lastmod.Format "02/01/2006" }}" />
@@ -41,7 +41,7 @@
 {{/* set custom CSP to load styles and scripts with special handling for GTM scripts (requires unsafe-inline) and Dev Portal page(s) (requires 'unsafe-eval') */}}
 <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'
     https://consent.trustarc.com/ https://mktg.tags.f5.com/basic/prod/utag.sync.js https://static.cloud.coveo.com/ https://*.f5.com/
-    https://*.netlify.app https://gist.github.com 
+    https://*.netlify.app https://gist.github.com
     https://tag.demandbase.com/pscSDsz4.min.js
     https://munchkin.brightfunnel.com/js/build/bf-munchkin.min.js
     https://www.googletagmanager.com/gtm.js
@@ -52,7 +52,7 @@
     https://cdn.bizible.com/xdc.js
     https://f5networksglobalprod.122.2o7.net/
     https://f5networksnginxdocs.122.2o7.net/
-    {{ if in .Params.doctypes "devportal" }} 'unsafe-eval' {{end}}; 
+    {{ if in .Params.doctypes "devportal" }} 'unsafe-eval' {{end}};
     worker-src 'self' blob:">
 {{/* end */}}
 
@@ -63,5 +63,5 @@
 
 <!-- Coveo metadata-->
 <meta name="product" content="{{ .Site.Title }}">
-<meta name="version" content="{{ .Site.Params.currentVersion }}"> 
+<meta name="version" content="{{ .Site.Params.currentVersion }}">
 <meta name="doc_type" content="Manual">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -11,7 +11,7 @@
         <div id="sidebar-content">
             <h3>
                 <a class="sidebar-title" href="{{.Site.Home.Permalink}}" alt="{{.Site.Title}}">{{ if .Site.Params.logo }}<img
-                        class="card-img-top" src="{{ .Site.BaseURL}}/images/icons/{{ .Site.Params.logo }}"
+                        class="card-img-top" src="{{ "/images/icons/" | absURL }}{{ .Site.Params.logo }}"
                         alt="{{.Site.Title}}">{{end}}
                     {{.Site.Title}}</a>
             </h3>

--- a/layouts/search/single.html
+++ b/layouts/search/single.html
@@ -3,7 +3,7 @@
 <div class="row flex-xl-nowrap">
   <main class="col-md-10 content" role="main">
     <div class="container"><h1>{{ .Title}}</h1></div>
-    
+
     <div id="search" class="CoveoSearchInterface" data-enable-history="true">
       <div class="CoveoFolding"></div>
       <div class="CoveoAnalytics" data-search-hub="HUB_ES_Nginx_Docs_And_Org"></div>
@@ -15,7 +15,7 @@
           <div class="CoveoFacet" data-title="Show by product" data-field="@f5_product" data-tab="All"
             data-number-of-values="15"></div>
           <div class="CoveoFacet" id="f5_product_module" data-title="Module" data-field="@f5_product_module" data-enable-settings="true" data-is-multi-value-field="true" data-number-of-values="10"></div>
-          <button id="reset_btn"><img src="{{ .Site.BaseURL }}/images/svg/refresh.svg">Reset</button>
+          <button id="reset_btn"><img src="{{ "/images/svg/refresh.svg" | absURL }}">Reset</button>
         </div>
         <div class="coveo-results-column">
           <div class="CoveoShareQuery"></div>
@@ -51,7 +51,7 @@
             <script id="Default" class="result-template" type="text/html" data-layout="list">
                   <div class="coveo-result-frame">
                     <div class="coveo-result-cell" style="vertical-align:top;text-align:center;width:32px;">
-                      <img src="{{.Site.BaseURL}}/images/article-icon.svg" alt="Article" height="32" width="32" title="Article" />
+                      <img src="{{ "/images/article-icon.svg" | absURL }}" alt="Article" height="32" width="32" title="Article" />
                     </div>
                     <div class="coveo-result-cell" style="vertical-align: top;padding-left: 16px;">
                       <div class="coveo-result-row" style="margin:0;">

--- a/layouts/success/single.html
+++ b/layouts/success/single.html
@@ -6,18 +6,18 @@
             <div class="d-xl-flex align-center justify-content-center p-4">
                 <h1>{{ .Title }}</h1>
             </div>
-            
+
             <div class="d-xl-flex align-center justify-content-center p-4">
-                <p>Your comments have been received. 
+                <p>Your comments have been received.
                 We appreciate you taking the time to give us feedback!</p>
             </div>
-            
+
             <div class="d-xl-flex align-center justify-content-center p-4">
-                <a class="btn btn-outline-success btn-lg" href="{{.Site.BaseURL}}" role="button">
+                <a class="btn btn-outline-success btn-lg" href="{{ "/" | absURL }}" role="button">
                   Go to the NGINX Docs Home page</a>
             </div>
         </div>
     </main>
-</div> 
+</div>
 
 {{ end }}


### PR DESCRIPTION
### Proposed changes

Replaces .Site.BaseURL with absURL as per https://gohugo.io/methods/site/baseurl/

for example:
`<p><a href="https://www.f5.com/"><img class="f5-logo-footer" src="{{.Site.BaseURL}}/images/icons/Logo_F5.svg" alt="F5 logo"></a>`

becomes 

`<p><a href="https://www.f5.com/"><img class="f5-logo-footer" src="{{ "/images/icons/Logo_F5.svg" | absURL }}" alt="F5 logo"></a>`

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
