### PR TITLE
docs: add shortcodes and CSS

### DIFF
--- a/assets/css/f5-hugo.css
+++ b/assets/css/f5-hugo.css
@@ -496,6 +496,35 @@ ul {
   padding: 0;
 }
 
+/* add css styles for tables with the fancy class */
+.fancy {
+   width: 100%;
+   border-collapse: collapse;
+}
+
+.fancy th, .fancy td {
+   padding: 8px;
+   text-align: left;
+}
+
+.fancy th {
+   background-color: #289951; /* Dark green */
+   color: white; /* White text for readability */
+}
+
+.fancy.table-striped > tbody > tr:nth-of-type(odd) {
+   background-color: #fff; /* White */
+}
+
+.fancy.table-striped > tbody > tr:nth-of-type(even) {
+   background-color: #f9f9f9; /* Light gray */
+}
+
+.fancy th, .fancy td {
+   border: none;
+}
+
+
 .section-heading {
   padding-top: 20px;
 }

--- a/assets/css/f5-hugo.css
+++ b/assets/css/f5-hugo.css
@@ -484,7 +484,6 @@ blockquote,
 dd,
 ol,
 p,
-table,
 ul {
   border: 0;
   font-family: inherit;
@@ -496,33 +495,27 @@ ul {
   padding: 0;
 }
 
-/* add css styles for tables with the fancy class */
-.fancy {
+table {
    width: 100%;
    border-collapse: collapse;
-}
-
-.fancy th, .fancy td {
+  }
+  th, td {
    padding: 8px;
    text-align: left;
-}
-
-.fancy th {
-   background-color: #289951; /* Dark green */
+  }
+  th {
+   background-color: #289951 ; /* Dark green */
    color: white; /* White text for readability */
-}
-
-.fancy.table-striped > tbody > tr:nth-of-type(odd) {
-   background-color: #fff; /* White */
-}
-
-.fancy.table-striped > tbody > tr:nth-of-type(even) {
+  }
+  .table-striped > tbody > tr:nth-of-type(odd) {
+    background-color: #fff; /* White */
+  }
+  .table-striped > tbody > tr:nth-of-type(even) {
    background-color: #f9f9f9; /* Light gray */
-}
-
-.fancy th, .fancy td {
+  }
+  th, td {
    border: none;
-}
+  }
 
 
 .section-heading {

--- a/layouts/shortcodes/before-you-begin.html
+++ b/layouts/shortcodes/before-you-begin.html
@@ -1,0 +1,3 @@
+<blockquote class="tip">
+   <div><strong>Before you begin:</strong><br/> {{ .Inner | markdownify }}</div>
+ </blockquote>

--- a/layouts/shortcodes/call-out.html
+++ b/layouts/shortcodes/call-out.html
@@ -1,0 +1,14 @@
+<!-- Blockquote element with a class that is the first parameter passed to the shortcode -->
+<blockquote class="{{ .Get 0 }}">
+   <div>
+     <!-- Check if the third parameter (icon class) is provided -->
+     {{ with .Get 2 }}
+       <!-- If the icon class is provided, render an <i> element with the given class -->
+       <i class="{{ . }}"></i>
+     {{ end }}
+     <!-- Render the second parameter (title) as a strong element -->
+     <strong>{{ .Get 1 }}</strong><br/>
+     <!-- Render the inner content of the shortcode, converting it from Markdown to HTML -->
+     {{ .Inner | markdownify }}
+   </div>
+ </blockquote>


### PR DESCRIPTION
### Proposed changes

Adds the call-out and before-you-being used in the docs repo to the theme.

Adds the CSS that was used in custom tables for NGINX One to the default styles for all tables.

before:

![image](https://github.com/user-attachments/assets/d5e2d59d-a2f0-419f-b4ae-c397c9f9e91b)


after:
 
![image](https://github.com/user-attachments/assets/93cb7da3-9bfc-4345-9aa4-237d42d2f476)

Follow ups after merge and release:
- Remove the shortcodes from the layouts folder in the docs repo
- Remove the custom styles in the NGINX one docs/branch
- Bump the theme/rebuild the docs in the `docs` repo

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
