### PR TITLE
Remove meta descriptions from displaying in user-facing HTML

### DIFF
--- a/layouts/_default/docs.html
+++ b/layouts/_default/docs.html
@@ -11,12 +11,10 @@
   {{ else }}
   <main class="content col d-block align-top content-no-toc" role="main">
   {{ end }}
-
     
     <h1>{{ .Title }}</h1>
 
       {{ if eq .Page.Draft true }}{{ partial "draft-badge.html" . }}{{ end }}
-      {{ if .Description }}<p>{{ .Description | markdownify }}</p>{{ end}}
 
       {{ if in .Params.doctypes "beta" }}{{ partial "beta-badge" . }}{{ end }}
   

--- a/layouts/feedback/single.html
+++ b/layouts/feedback/single.html
@@ -4,8 +4,6 @@
   <main class="col-xl-6 d-block" role="main">
     <div class="container">
       <h1 class="align-center">{{ .Title }}</h1>
-      {{ if .Description }}
-      <p class="muted align-center pb-4">{{ .Description | markdownify }}</p><hr>{{ end}}
       {{ if .Content }}
       <div class="pb-4 mb-2">{{ .Content }}</div>
       {{ end }}

--- a/layouts/ossc/single.html
+++ b/layouts/ossc/single.html
@@ -4,14 +4,11 @@
   <main class="col-xl-8 d-block" role="main">
     <div class="container">
       <h1 class="align-center">{{ .Title }}</h1>
-      {{ if .Description }}
-      <p class="muted align-center pb-4">{{ .Description | markdownify }}</p><hr>{{ end}}
       {{ if .Content }}
       <div class="pb-4 mb-2">{{ .Content }}</div>
       {{ end }}
     </div>
   </main>
 </div>
-
 
 {{ end }}

--- a/layouts/partials/list-main.html
+++ b/layouts/partials/list-main.html
@@ -4,11 +4,6 @@
             <h1 class="bd-title">
                 {{ .Title }}
             </h1>
-            {{ if .Description }}
-                <p class="bd-lead">
-                    {{ .Description | markdownify }}
-                </p>
-            {{ end}}
             {{ if .Content }}
                 <p class="bd-lead">
                     {{ .Content | markdownify }}
@@ -28,9 +23,6 @@
                             <i class="fas fa-{{if eq .Kind "page"}}file-alt{{else}}book{{end}} fa-2x card-img-top"></i>
                             <a href="{{ if .Params.url}}{{ .Params.url}}{{else}}{{ .Permalink }}{{end}}">{{ .Title }}</a>
                         </h3>
-                        {{/*}}<p class="card-text">
-                            {{ if .Description }}{{ .Description | markdownify }}{{ end }}    
-                        </p>{{*/}}
                     </div>
                 </div>
                 {{ end }}

--- a/layouts/partials/page-summary.html
+++ b/layouts/partials/page-summary.html
@@ -3,7 +3,4 @@
         <a href="{{ .Permalink }}" itemprop="headline">{{ .Title }}</a>
     </h2>
     <hr>
-    {{ if .Description }}
-    <p itemprop="about">{{ .Description | markdownify }}</p>
-    {{ end }}
 </li>

--- a/layouts/partials/taxonomy-list.html
+++ b/layouts/partials/taxonomy-list.html
@@ -4,11 +4,6 @@
             <h1 class="bd-title">
                 {{ .Title | humanize }} Index
             </h1>
-            {{ if .Description }}
-                <p class="bd-lead">
-                    {{ .Description | markdownify }}
-                </p>
-            {{ end}}
             {{ if .Content }}
                 <p class="bd-lead">
                     {{ .Content | markdownify }}


### PR DESCRIPTION
### Proposed changes

This pull request removes meta descriptions from displaying in user-facing HTML.

It's a long-standing bug with the theme.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
