### PR TITLE
chore: update deprecated helper functions

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -18,7 +18,7 @@
 {{ partial "head_custom.html" . }}
 {{ end }}
 
-{{ if or ( not .Site.IsServer ) ( not ( in .Site.Params.buildtype "package" ) ) }}
+{{ if or ( not hugo.IsServer ) ( not ( in .Site.Params.buildtype "package" ) ) }}
       
 {{ partial "trustarc.html" . }}
 
@@ -37,7 +37,7 @@
 </head>
 
 <body>
-  {{ if or ( not .Site.IsServer ) ( not ( in .Site.Params.buildtype "package" ) ) }} 
+  {{ if or ( not hugo.IsServer ) ( not ( in .Site.Params.buildtype "package" ) ) }}
 {{ partial "universal-tag.html" . }}
   {{ end }}
 

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -59,7 +59,7 @@
 <!-- build metadata -->
 <meta property="environment" type="{{ hugo.Environment }}" />
 <meta property="buildtype" type="{{ .Site.Params.buildtype }}" />
-<meta property="isServer" type="{{ .Site.IsServer }}" />
+<meta property="isServer" type="{{ hugo.IsServer }}" />
 
 <!-- Coveo metadata-->
 <meta name="product" content="{{ .Site.Title }}">

--- a/theme.toml
+++ b/theme.toml
@@ -7,7 +7,7 @@ licenselink = "https://github.com/nginxinc/nginx-hugo-theme/blob/main/LICENSE"
 description = "Hugo theme for F5 NGINX documentation"
 homepage = "https://docs.nginx.com/"
 
-min_version = "0.74.3"
+min_version = "0.128.0"
 
 [author]
   name = "F5, Inc."


### PR DESCRIPTION
Calls to `.Site.IsServer` were preventing upgrading to a newer version of Hugo.

As such, the minimum supported version has been bumped.

Related: https://github.com/nginxinc/docs-platform/issues/205