### PR TITLE
Add console based theme switcher

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -1,0 +1,3 @@
+html {
+    background-color: lightgreen;
+}

--- a/assets/js/theme-switcher.js
+++ b/assets/js/theme-switcher.js
@@ -1,0 +1,29 @@
+if (localStorage.getItem("useNewTheme") === "true") {
+  useNewTheme(true);
+}
+
+function useNewTheme(useNewTheme) {
+  localStorage.setItem("useNewTheme", `${useNewTheme}`);
+
+  const v1cssIds = [
+    "cssFA1",
+    "cssFA2",
+    "cssFA3",
+    "cssBootstrap",
+    "css1",
+    "css2",
+    "css3",
+    "css4",
+    "css5",
+    "css6",
+  ];
+
+  v1cssIds.forEach((cssId) => {
+    document.getElementById(cssId).disabled = useNewTheme;
+  });
+
+  const v2cssIds = ["css7"];
+  v2cssIds.forEach((cssId) => {
+    document.getElementById(cssId).disabled = !useNewTheme;
+  });
+}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -6,11 +6,12 @@
 
 <!-- load Bootstrap from local assets -->
 {{ $jsBootstrap := resources.Get "js/bootstrap.bundle.min.js" | fingerprint "sha512" }}
-<script src="{{ $jsBootstrap.RelPermalink }}" type="text/javascript" integrity="{{ $jsBootstrap.Data.Integrity }}"></script>
+<script src="{{ $jsBootstrap.RelPermalink }}" type="text/javascript"
+  integrity="{{ $jsBootstrap.Data.Integrity }}"></script>
 
 <!-- load code copy js -->
 {{ $codecopy := resources.Get "/js/code-copy.js" | fingerprint "sha512" }}
-<script src="{{ $codecopy.RelPermalink }}" type="text/javascript" ></script>
+<script src="{{ $codecopy.RelPermalink }}" type="text/javascript"></script>
 
 <!-- load mermaid.js -->
 {{ if .Page.Store.Get "hasMermaid" }}
@@ -19,9 +20,13 @@
 {{ end }}
 
 <!-- START COVEO -->
-<script class="coveo-script" src="https://static.cloud.coveo.com/searchui/v2.10104/0/js/CoveoJsSearch.Lazy.min.js" integrity="sha512-HxdDBIp5snbqtu1TPkBnXLKEvN9IPz3PeZW8zT9KfsflV9Ck822XDroDlpVbfCfXeiu8C0RDVn0fdu7aGy/H1g==" crossorigin="anonymous"></script>
+<script class="coveo-script" src="https://static.cloud.coveo.com/searchui/v2.10104/0/js/CoveoJsSearch.Lazy.min.js"
+  integrity="sha512-HxdDBIp5snbqtu1TPkBnXLKEvN9IPz3PeZW8zT9KfsflV9Ck822XDroDlpVbfCfXeiu8C0RDVn0fdu7aGy/H1g=="
+  crossorigin="anonymous"></script>
 
-<script src="https://static.cloud.coveo.com/searchui/v2.10104/0/js/templates/templates.js" integrity="sha512-CR0Yk/LIwgh1MsKqjecDp/r6F9ipKc6gA+4+E1pplT3N3r1pk+la/HaqyDiKtjOFwrwIIbIYBFrUJgPql93QHw==" crossorigin="anonymous"></script>
+<script src="https://static.cloud.coveo.com/searchui/v2.10104/0/js/templates/templates.js"
+  integrity="sha512-CR0Yk/LIwgh1MsKqjecDp/r6F9ipKc6gA+4+E1pplT3N3r1pk+la/HaqyDiKtjOFwrwIIbIYBFrUJgPql93QHw=="
+  crossorigin="anonymous"></script>
 
 <!-- build coveo.js -->
 {{ $.Scratch.Set "coveoSc" "" }}
@@ -30,18 +35,19 @@
 {{ $secureCoveo := $.Scratch.Get "coveoSc" | minify | fingerprint "sha512" }}
 
 
-<script src="{{ $secureCoveo.RelPermalink }}" integrity="{{ $secureCoveo.Data.Integrity }}" type="text/javascript"></script>
+<script src="{{ $secureCoveo.RelPermalink }}" integrity="{{ $secureCoveo.Data.Integrity }}"
+  type="text/javascript"></script>
 
 
 
 <!-- Load the Redoc resources if we're not using Dev Portal for the API reference layout-->
 {{ if not ( eq .Site.Params.useDevPortal true ) }}
 
-  {{ $redoc := resources.Get "js/redoc.standalone.js" }}
-  {{ $redoc := $redoc | fingerprint "sha512" }}
+{{ $redoc := resources.Get "js/redoc.standalone.js" }}
+{{ $redoc := $redoc | fingerprint "sha512" }}
 
-  <!-- only load the redoc js if we're on an api reference page -->
-  {{ if and (in .Params.doctypes "reference") (in .Params.tags "api") }}
+<!-- only load the redoc js if we're on an api reference page -->
+{{ if and (in .Params.doctypes "reference") (in .Params.tags "api") }}
 <script src="{{$redoc.RelPermalink}}" type="text/javascript"></script>{{ end }}
 
 {{ end }}
@@ -49,3 +55,8 @@
 <!-- Load Sidebar javascript -->
 {{ $jsSidebar := resources.Get "js/sidebar.js" | minify | fingerprint "sha512" }}
 <script src="{{ $jsSidebar.RelPermalink }}" type="text/javascript" integrity="{{ $jsSidebar.Data.Integrity }}"></script>
+
+<!-- Inline theme switcher -->
+{{ $jsThemeSwitcher := resources.Get "js/theme-switcher.js" | minify | fingerprint "sha512" }}
+<script src="{{ $jsThemeSwitcher.RelPermalink }}" type="text/javascript"
+  integrity="{{ $jsThemeSwitcher.Data.Integrity }}"></script>

--- a/layouts/partials/styles.html
+++ b/layouts/partials/styles.html
@@ -4,47 +4,58 @@
 {{ $css4 := resources.Get "css/f5-hugo.css" }}
 {{ $css5 := resources.Get "css/highlight.css" }}
 {{ $css6 := resources.Get "css/coveo.css" }}
+{{ $css7 := resources.Get "css/v2/style.css" }}
+
+<!-- load v2 theme assets -->
+<link href="{{ $css7.RelPermalink }}" integrity="{{ $css7.Data.Integrity }}" rel="stylesheet" type="text/css" id="css7"
+  disabled>
 
 <!-- load FontAwesome from assets -->
 {{ $cssFA1 := resources.Get "fontawesome/css/all.min.css" | fingerprint "sha512" }}
-<link href="{{ $cssFA1.RelPermalink }}" integrity="{{ $cssFA1.Data.Integrity }}" rel="stylesheet" type="text/css">
+<link href="{{ $cssFA1.RelPermalink }}" integrity="{{ $cssFA1.Data.Integrity }}" rel="stylesheet" type="text/css"
+  id="cssFA1">
 
 {{ $cssFA2 := resources.Get "fontawesome/css/v4-font-face.min.css" | fingerprint "sha512" }}
-<link href="{{ $cssFA2.RelPermalink }}" integrity="{{ $cssFA2.Data.Integrity }}" rel="stylesheet" type="text/css">
+<link href="{{ $cssFA2.RelPermalink }}" integrity="{{ $cssFA2.Data.Integrity }}" rel="stylesheet" type="text/css"
+  id="cssFA2">
 
 {{ $cssFA3 := resources.Get "fontawesome/css/v5-font-face.min.css" | fingerprint "sha512" }}
-<link href="{{ $cssFA3.RelPermalink }}" integrity="{{ $cssFA3.Data.Integrity }}" rel="stylesheet" type="text/css">
+<link href="{{ $cssFA3.RelPermalink }}" integrity="{{ $cssFA3.Data.Integrity }}" rel="stylesheet" type="text/css"
+  id="cssFA3">
 
-<!-- load Bootstrap from local assets -->  
+<!-- load Bootstrap from local assets -->
 {{ $cssBootstrap := resources.Get "css/bootstrap.min.css" | fingerprint "sha512" }}
-<link href="{{ $cssBootstrap.RelPermalink }}" integrity="{{ $cssBootstrap.Data.Integrity }}" rel="stylesheet" type="text/css">
+<link href="{{ $cssBootstrap.RelPermalink }}" integrity="{{ $cssBootstrap.Data.Integrity }}" rel="stylesheet"
+  type="text/css" id="cssBootstrap">
 
 {{ if ( not ( in .Site.Params.buildtype "package" ) ) }}
 <!-- load Coveo CSS -->
-<link rel="stylesheet" href="https://static.cloud.coveo.com/searchui/v2.10104/0/css/CoveoFullSearch.min.css" integrity="sha512-9/A9yVCU4GS6/iIwTRJKnan4Hf8gDKj3anwItN9QCsU8SixaT5xkjjWsZ/iq0TWaizhtqOLacadXJfxHlwYCcA==" crossorigin="anonymous" />{{ end }}
+<link rel="stylesheet" href="https://static.cloud.coveo.com/searchui/v2.10104/0/css/CoveoFullSearch.min.css"
+  integrity="sha512-9/A9yVCU4GS6/iIwTRJKnan4Hf8gDKj3anwItN9QCsU8SixaT5xkjjWsZ/iq0TWaizhtqOLacadXJfxHlwYCcA=="
+  crossorigin="anonymous" />{{ end }}
 
 {{ $cssHeader := $css1 | minify | fingerprint "sha512"}}
-<link href="{{ $cssHeader.RelPermalink }}" rel="stylesheet" type="text/css">
+<link href="{{ $cssHeader.RelPermalink }}" rel="stylesheet" type="text/css" id="css1">
 
 {{ $cssNginxStyles := $css2 | minify | fingerprint "sha512"}}
-<link href="{{ $cssNginxStyles.RelPermalink }}" rel="stylesheet" type="text/css">
+<link href="{{ $cssNginxStyles.RelPermalink }}" rel="stylesheet" type="text/css" id="css2">
 
 {{ $bootstrapDocs := $css3 | minify | fingerprint "sha512"}}
-<link href="{{ $bootstrapDocs.RelPermalink }}" rel="stylesheet" type="text/css">
+<link href="{{ $bootstrapDocs.RelPermalink }}" rel="stylesheet" type="text/css" id="css3">
 
 {{ if ( not ( in .Site.Params.buildtype "package" ) ) }}
 {{ $cssCoveo := $css6 | minify | fingerprint "sha512"}}
-<link href="{{ $cssCoveo.RelPermalink }}" rel="stylesheet" type="text/css">
+<link href="{{ $cssCoveo.RelPermalink }}" rel="stylesheet" type="text/css" id="css6">
 {{ end }}
 
 {{ $cssF5Hugo := $css4 | minify | fingerprint "sha512"}}
-<link href="{{ $cssF5Hugo.RelPermalink }}" rel="stylesheet" type="text/css">
+<link href="{{ $cssF5Hugo.RelPermalink }}" rel="stylesheet" type="text/css" id="css4">
 
 {{ if fileExists "assets/css/custom.css" }}
-  {{ $customCSS := resources.Get "css/custom.css" | minify | fingerprint "sha512" }}
-  <link href="{{ $customCSS.RelPermalink }}" rel="stylesheet" type="text/css">
+{{ $customCSS := resources.Get "css/custom.css" | minify | fingerprint "sha512" }}
+<link href="{{ $customCSS.RelPermalink }}" rel="stylesheet" type="text/css">
 {{ end }}
 
 <!-- load Highlight CSS -->
 {{ $cssHighlight := $css5 | minify | fingerprint "sha512"}}
-<link href="{{ $cssHighlight.RelPermalink }}" rel="stylesheet" type="text/css">
+<link href="{{ $cssHighlight.RelPermalink }}" rel="stylesheet" type="text/css" id="css5">


### PR DESCRIPTION
### Proposed changes

Add _very_ basic theme switcher. 
It can be toggled in the developer console using `useNewTheme(true)` to enable the new theme or `useNewTheme(false)` to disable it.

The last value set is stored in local storage so you can browse around the site with your theme of choice.

There's a slightly flicker changing pages on the new theme, since the old theme is enabled by default.
