### PR TITLE
Add ghcode shortcode for rendering github content

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ This theme contains the following custom shorcodes:
 
 - openapi.html - Render an OpenAPI spec using ReDoc.
 - metrics.html - Imports data from a JSON file and presents it in table format.
+- ghcode.html - Rendering code from github
+
+#### `ghcode` example
+To render code directly from github at build time, you can use the `ghcode` shortcode.
+
+_Param 1_ - The url for the `raw` github file you want to render
+
+_Param 2_ - Options for highlighting following Hugo's [Highlight shortcode](https://gohugo.io/content-management/syntax-highlighting/#highlight-shortcode)
+
+```
+{{< ghcode "https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/refs/heads/main/examples/custom-resources/access-control/access-control-policy-allow.yaml" "hl_lines=4" >}}
+```
+
+
 
 ### Includes
 

--- a/layouts/shortcodes/ghcode.html
+++ b/layouts/shortcodes/ghcode.html
@@ -1,0 +1,12 @@
+{{ $file := .Get 0 }}
+{{ $params := .Get 1 }}
+{{ with resources.GetRemote $file }}
+  {{ with .Err }}
+    {{ errorf "%s" . }}
+  {{ else }}
+    {{ $lang := path.Ext $file | strings.TrimPrefix "." }}
+    {{ highlight .Content $lang $params }}
+  {{ end }}
+{{ else }}
+  {{ errorf "Unable to load github content from %s from %q" $file .Position}}
+{{ end }}


### PR DESCRIPTION
### Proposed changes
Adds shortcode for rendering github content at build time.
```
{{< ghcode "https://raw.githubusercontent.com/nginxinc/kubernetes-ingress/refs/heads/main/examples/custom-resources/access-control/access-control-policy-allow.yaml" "hl_lines=4" >}}
```

If the url provided does not exist, it will throw an error referencing the url and source of shortcode usage.

```
ERROR Unable to load github content from https://raw.githubusercontent.com/nginrnetes-is/heads/main/examples/custom-resources/access-control/access-control-policy-allow.yaml from "\x1b[1;36m\"/Users/j.hickey/Documents/github/docs/content/nginx-one/about.md:29:1\"\x1b[0m"
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
