### PR TITLE
Add last-modified section to bottom of docs pages

### DIFF
--- a/assets/css/f5-hugo.css
+++ b/assets/css/f5-hugo.css
@@ -1649,3 +1649,7 @@ li.nav-item a.nav-link {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }
+
+.last-modified {
+  font-weight:300;
+}

--- a/layouts/_default/docs.html
+++ b/layouts/_default/docs.html
@@ -21,8 +21,14 @@
     {{ .Content }}
     {{ partial "version-list" . }}
   <hr>
+
+  {{ if .Page.Lastmod }}
+  <div class="last-modified">
+    Last modified {{ .Page.Lastmod.Format "January 2, 2006" }}
+  </div>
+  {{ end }}
+
     {{ partial "previous-next-links-in-section-with-title.html" . }}
-    
   </main>
   {{ if and (gt .WordCount 200 ) (.Params.toc) }}
     {{ if (add  (len (findRE "<h3" .Content)) (len (findRE "<h2" .Content))) }}
@@ -31,6 +37,7 @@
       </div>
     {{ end }}
   {{ end }}
+
 </div>
 <!-- If there is a script defined in the page metadata, load it  -->
 {{if .Params.script}}


### PR DESCRIPTION
### Proposed changes

Add last-modified section to bottom of docs pages.

<img width="437" alt="Screenshot 2024-10-03 at 14 51 59" src="https://github.com/user-attachments/assets/c14b54d3-300e-4c75-a04d-f2fdca13de99">


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
