### PR TITLE
Add docs.html theme switcher and placeholder sidebar

### DIFF
--- a/assets/js/theme-switcher.js
+++ b/assets/js/theme-switcher.js
@@ -5,6 +5,7 @@ if (localStorage.getItem("useNewTheme") === "true") {
 function useNewTheme(useNewTheme) {
   localStorage.setItem("useNewTheme", `${useNewTheme}`);
 
+  // swap out v1 and v2 css style
   const v1cssIds = [
     "cssFA1",
     "cssFA2",
@@ -15,7 +16,7 @@ function useNewTheme(useNewTheme) {
     "css3",
     "css4",
     "css5",
-    "css6",
+    "css6"
   ];
 
   v1cssIds.forEach((cssId) => {
@@ -26,4 +27,17 @@ function useNewTheme(useNewTheme) {
   v2cssIds.forEach((cssId) => {
     document.getElementById(cssId).disabled = !useNewTheme;
   });
+
+  // swap out v1 and v2 elements
+  const v1ElementIds = ["main-content"]
+
+  v1ElementIds.forEach((elementId) => {
+    document.getElementById(elementId).style.display = useNewTheme ? "none" : "";
+  });
+
+  const v2ElementIds = ["main-content-v2"];
+  v2ElementIds.forEach((elementId) => {
+    document.getElementById(elementId).style.display = useNewTheme ? "": "none";
+  });
+
 }

--- a/layouts/_default/docs.html
+++ b/layouts/_default/docs.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-<div class="row override-sidebar-collapse">
+<div id="main-content" class="row override-sidebar-collapse">
   <nav class="sidenav overflow-auto col-md-3 d-none d-xl-block d-print-none align-top">
     {{ partial "sidebar.html" . }}
   </nav>
@@ -37,8 +37,50 @@
       </div>
     {{ end }}
   {{ end }}
-
 </div>
+
+
+<div id="main-content-v2" class="row override-sidebar-collapse" style="display: none;">
+  <nav class="sidenav overflow-auto col-md-3 d-none d-xl-block d-print-none align-top">
+    {{ partial "sidebar-v2.html" . }}
+  </nav>
+  
+  {{if (.Params.catalog) }}
+  <main class="content content-has-toc" role="main">
+  {{ else if and (gt .WordCount 200 ) (.Params.toc) }}
+  <main class="content col d-block align-top content-has-toc" role="main">
+  {{ else }}
+  <main class="content col d-block align-top content-no-toc" role="main">
+  {{ end }}
+    
+    <h1>{{ .Title }}</h1>
+
+      {{ if eq .Page.Draft true }}{{ partial "draft-badge.html" . }}{{ end }}
+
+      {{ if in .Params.doctypes "beta" }}{{ partial "beta-badge" . }}{{ end }}
+  
+    {{ .Content }}
+    {{ partial "version-list" . }}
+  <hr>
+
+  {{ if .Page.Lastmod }}
+  <div class="last-modified">
+    Last modified {{ .Page.Lastmod.Format "January 2, 2006" }}
+  </div>
+  {{ end }}
+
+    {{ partial "previous-next-links-in-section-with-title.html" . }}
+  </main>
+  {{ if and (gt .WordCount 200 ) (.Params.toc) }}
+    {{ if (add  (len (findRE "<h3" .Content)) (len (findRE "<h2" .Content))) }}
+      <div class="col-md-3 d-none d-xl-block d-print-none nginx-toc align-top">
+      {{ partial "toc.html" . }}
+      </div>
+    {{ end }}
+  {{ end }}
+</div>
+
+
 <!-- If there is a script defined in the page metadata, load it  -->
 {{if .Params.script}}
   {{ $script := (delimit (slice "scripts" .Params.script) "/")}}

--- a/layouts/partials/sidebar-v2.html
+++ b/layouts/partials/sidebar-v2.html
@@ -1,0 +1,3 @@
+<div>
+sidebar-v2 placeholder
+</div>


### PR DESCRIPTION
### Proposed changes

Add docs.html theme switcher and placeholder sidebar.
Only one of either v1 or v2 will be _rendered_ at a time, however, the html will contain double sets of content.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
