### PR TITLE
Add sidebar swapper

### DIFF
--- a/assets/js/theme-switcher.js
+++ b/assets/js/theme-switcher.js
@@ -5,6 +5,7 @@ if (localStorage.getItem("useNewTheme") === "true") {
 function useNewTheme(useNewTheme) {
   localStorage.setItem("useNewTheme", `${useNewTheme}`);
 
+  // swap out v1 and v2 css style
   const v1cssIds = [
     "cssFA1",
     "cssFA2",
@@ -15,7 +16,7 @@ function useNewTheme(useNewTheme) {
     "css3",
     "css4",
     "css5",
-    "css6",
+    "css6"
   ];
 
   v1cssIds.forEach((cssId) => {
@@ -26,4 +27,17 @@ function useNewTheme(useNewTheme) {
   v2cssIds.forEach((cssId) => {
     document.getElementById(cssId).disabled = !useNewTheme;
   });
+
+  // swap out v1 and v2 elements
+  const v1ElementIds = ["sidebar"]
+
+  v1ElementIds.forEach((elementId) => {
+    document.getElementById(elementId).style.display = useNewTheme ? "none" : "";
+  });
+
+  const v2ElementIds = ["sidebar-v2"];
+  v2ElementIds.forEach((elementId) => {
+    document.getElementById(elementId).style.display = useNewTheme ? "": "none";
+  });
+
 }

--- a/layouts/_default/docs.html
+++ b/layouts/_default/docs.html
@@ -1,7 +1,11 @@
 {{ define "main" }}
 <div class="row override-sidebar-collapse">
-  <nav class="sidenav overflow-auto col-md-3 d-none d-xl-block d-print-none align-top">
+  <nav id="sidebar" class="sidenav overflow-auto col-md-3 d-none d-xl-block d-print-none align-top">
     {{ partial "sidebar.html" . }}
+  </nav>
+
+  <nav id="sidebar-v2" class="" style="display:none">
+    Sidebar placeholder
   </nav>
   
   {{if (.Params.catalog) }}


### PR DESCRIPTION
### Proposed changes

Add sidebar swapper.
**Expected behaviour:**
- On visiting the page without having used `useNewTheme`, the current side bar should be visible
- After running `useNewTheme(true)` in your browser console, the sidebar should be replaced with the text "Sidebar placeholder" and the new theme should be visible
- Running `useNewTheme(false)` should revert back to the current styling
- Refreshing the page should _keep the same state as before the refresh_, be it theme true or theme false

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
