### PR TITLE
Fix lineos=true breaking copy to clipboard

### DIFF
--- a/assets/js/code-copy.js
+++ b/assets/js/code-copy.js
@@ -1,33 +1,31 @@
 function CopyCode(clipboard) {
-    document.querySelectorAll('pre > code').forEach(function(codeBlock) {
-        var button = document.createElement('button');
-        button.className = 'code-copy';
-        button.type = 'button';
-        button.innerHTML = '<i class="fas fa-copy"></i> Copy';
+  document.querySelectorAll(".highlight").forEach((codeBlock) => {
+    const button = document.createElement("button");
+    button.className = "code-copy";
+    button.type = "button";
+    button.innerHTML = '<i class="fas fa-copy"></i> Copy';
 
-        button.addEventListener('click', function() {
-            // removes return carriage from copied text
-            clipboard.writeText(codeBlock.textContent.replace(/\n$/g, "")).then(
-                function() {
-                    button.blur(); /* Chrome fix */
-                    button.innerHTML = '<i class="fas fa-check"></i> Copied!';
-                    setTimeout(function() {
-                        button.innerHTML = '<i class="fas fa-copy"></i> Copy';
-                    }, 2000);
-                },
-                function(error) {
-                    button.innerHTML = '<i class="fas fa-exclamation"></i> Error';
-                    console.error(error);
-                }
-            );
-        });
+    button.addEventListener("click", async () => {
+      try {
+        await clipboard.writeText(
+          codeBlock.textContent
+            .replace(/^\s*\d+\s/gm, "") // remove line numbers
+            .replace(/^\s*|\s*$/g, "") // remove carriage returns at top and bottom of block
+        );
 
-        var pre = codeBlock.parentNode;
-        if (pre.parentNode.classList.contains('highlight')) {
-            var highlight = pre.parentNode;
-            highlight.parentNode.insertBefore(button, highlight);
-        }
+        button.blur(); /* Chrome fix */
+        button.innerHTML = '<i class="fas fa-check"></i> Copied!';
+        setTimeout(() => {
+          button.innerHTML = '<i class="fas fa-copy"></i> Copy';
+        }, 2000);
+      } catch (error) {
+        button.innerHTML = '<i class="fas fa-exclamation"></i> Error';
+        console.error(error);
+      }
     });
+
+    codeBlock.parentNode.insertBefore(button, codeBlock);
+  });
 }
 
 CopyCode(navigator.clipboard);


### PR DESCRIPTION
Change selector used to the .highlight class
Add regex to remove line numbers
Update regex to remove carriage returns start and end of block

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
