### PR TITLE
Fetching URL for qualtrics surveys

### DIFF
--- a/layouts/partials/qualtrics-feedback.html
+++ b/layouts/partials/qualtrics-feedback.html
@@ -44,7 +44,7 @@
             if(this.check()){
                 var a=document.createElement("script");
                 a.type="text/javascript";
-                a.src=g + `?SourcePage=${document.URL}`;
+                a.src=g + `?SourcePage=${encodeURIComponent(document.URL)}`;
                 document.body&&document.body.appendChild(a)
             }
         }; 

--- a/layouts/partials/qualtrics-feedback.html
+++ b/layouts/partials/qualtrics-feedback.html
@@ -44,7 +44,8 @@
             if(this.check()){
                 var a=document.createElement("script");
                 a.type="text/javascript";
-                a.src=g;document.body&&document.body.appendChild(a)
+                a.src=g + `?SourcePage=${document.URL}`;
+                document.body&&document.body.appendChild(a)
             }
         }; 
         


### PR DESCRIPTION
### Proposed changes

- Added to src attribute a new parameter in order to retrieve the URL for qualtrics to read and present when looking at responses from customers.
- Requirements from Irving:
![Screenshot 2025-01-08 at 12 17 53 PM](https://github.com/user-attachments/assets/3c145b30-b71f-4d37-b7f8-f8296e2f3cec)
- Resolves: https://github.com/nginxinc/docs-platform/issues/294


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
