### PR TITLE
Add coveo jwt caching

### DIFF
--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -1,56 +1,82 @@
-document.addEventListener('DOMContentLoaded', async function () {
+function isJwtExpired(token) {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    return true;
+  }
 
-    // Netlify function to get the coveo search token via API
-    async function getsearchObj() {
-      const response = await fetch(
-        window.location.origin+"/api/v1/auth/search_token"
+  const [_, payload] = parts;
+  const decodedPayload = atob(payload);
+  const payloadObj = JSON.parse(decodedPayload);
+
+  const currentTime = Math.floor(Date.now() / 1000);
+  const expTime = payloadObj.exp;
+  return currentTime >= expTime;
+}
+
+async function getsearchObj() {
+  const response = await fetch(
+    window.location.origin + "/api/v1/auth/search_token"
+  );
+  return response.json();
+}
+
+document.addEventListener("DOMContentLoaded", async function () {
+  const token = localStorage.getItem("coveo_jwt_v1");
+  const org_id = localStorage.getItem("coveo_org_id_v1");
+  let searchObj = { token, org_id };
+  if (token === null || org_id === null || isJwtExpired(token)) {
+    searchObj = await getsearchObj();
+    localStorage.setItem("coveo_jwt_v1", searchObj.token);
+    localStorage.setItem("coveo_org_id_v1", searchObj.org_id);
+  }
+
+  Coveo.SearchEndpoint.configureCloudV2Endpoint(
+    searchObj.org_id,
+    searchObj.token,
+    `https://${searchObj.org_id}.org.coveo.com/rest/search`
+  );
+
+  const analyticsElement = document.querySelector(".CoveoAnalytics");
+  if (analyticsElement) {
+    const analyticsEndpoint = `https://${searchObj.org_id}.analytics.org.coveo.com/rest/ua`;
+    analyticsElement.setAttribute("data-endpoint", analyticsEndpoint);
+  }
+
+  const root = document.getElementById("search");
+  const searchBoxRoot = document.getElementById("searchbox");
+  Coveo.initSearchbox(searchBoxRoot, "/search.html");
+  var resetbtn = document.querySelector("#reset_btn");
+  if (resetbtn) {
+    resetbtn.onclick = function () {
+      document.querySelector(".coveo-facet-header-eraser").click();
+    };
+  }
+  Coveo.$$(root).on("querySuccess", function (e, args) {
+    resetbtn.style.display = "block";
+  });
+  Coveo.$$(root).on("afterComponentsInitialization", function (e, data) {
+    setTimeout(function () {
+      document.querySelector(".CoveoOmnibox input").value = Coveo.state(
+        root,
+        "q"
       );
-      return response.json();
+    }, 1000);
+  });
+  Coveo.$("#search").on("newResultsDisplayed", function (e, args) {
+    for (var i = 0; i < e.target.lastChild.children.length; i++) {
+      //Remove the title for tooltip box
+      Coveo.$(".CoveoResultLink").removeAttr("title");
     }
-
-    const searchObj = await getsearchObj()
-    Coveo.SearchEndpoint.configureCloudV2Endpoint(searchObj.org_id, searchObj.token, `https://${searchObj.org_id}.org.coveo.com/rest/search`);
-
-    const analyticsElement = document.querySelector('.CoveoAnalytics');
-    if (analyticsElement) {
-      const analyticsEndpoint = `https://${searchObj.org_id}.analytics.org.coveo.com/rest/ua`;
-      analyticsElement.setAttribute('data-endpoint', analyticsEndpoint);
-    }
-
-    const root = document.getElementById("search");
-    const searchBoxRoot = document.getElementById("searchbox");
-    Coveo.initSearchbox(searchBoxRoot, "/search.html");
-    var resetbtn = document.querySelector('#reset_btn');
-    if (resetbtn) {
-      resetbtn.onclick = function () {
-        document.querySelector('.coveo-facet-header-eraser').click();
-      };
-    }
-    Coveo.$$(root).on("querySuccess", function (e, args) {
-      resetbtn.style.display = "block";
-    });
-    Coveo.$$(root).on('afterComponentsInitialization', function (e, data) {
-      setTimeout(function () {
-        document.querySelector('.CoveoOmnibox input').value = Coveo.state(root, 'q');
-      }, 1000);
-    });
-    Coveo.$('#search').on("newResultsDisplayed", function (e, args) {
-      for (var i = 0; i < e.target.lastChild.children.length; i++) {
-        //Remove the title for tooltip box  
-        Coveo.$('.CoveoResultLink').removeAttr('title');         
-      }
-    });
-    Coveo.init(root, {
-      f5_product_module: {
-        dependsOn: "@f5_product",
-        dependsOnCondition: (parentFacet) => {
-          const id = parentFacet.options.id;
-          const value = "NGINX Management Suite";
-          const selected = parentFacet.queryStateModel.get(`f:${id}`)
-          return selected.includes(value);
-        }
-      }
-    });
-  })
-  
-  
+  });
+  Coveo.init(root, {
+    f5_product_module: {
+      dependsOn: "@f5_product",
+      dependsOnCondition: (parentFacet) => {
+        const id = parentFacet.options.id;
+        const value = "NGINX Management Suite";
+        const selected = parentFacet.queryStateModel.get(`f:${id}`);
+        return selected.includes(value);
+      },
+    },
+  });
+});


### PR DESCRIPTION
Add coveo jwt caching.

This change will store the coveo org id and token as a JWT in localstorage.
When the page is bootstrapping, it will check local storage for the token _and_ check if the token is valid.
It will use the token from cache if it's still valid, or make a request for a new one if it has expired.

The goal of this is to stop the persistent reloading of the search input box on page change, and this seems to achieve that 👌 .

Note: Security wise, this JWT is already visible in plain text looking in the network tab. Given coveos strict CORS and short token life, storing this in local storage isn't an issue.