### PR TITLE
Tooling: Add setup-pre-commit make target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ Follow our [Getting Started Guide](https://github.com/nginxinc/nginx-hugo-theme/
 We use [pre-commit](https://pre-commit.com/#install) for local pre-commit hooks.
 To get setup:
 - Install [pre-commit ](https://pre-commit.com/#install)
-- Install the hooks `pre-commit install`
+- Run the make target `make setup-pre-commit`
 
 ### Report a Bug
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ list help::
 	@echo "		   biome-all:		Runs both the lint and formatting commands."
 	@echo "  (Set BIOME_ARGS to add additional arguments to biome command (ex: make biome-all BIOME_ARGS=write))"
 
-.PHONY: biome-format biome-lint biome-all 
+.PHONY: biome-format biome-lint biome-all setup-pre-commit
 BIOME_ARGS ?= 
 FLAG :=
 ifeq ($(BIOME_ARGS), write)
@@ -26,3 +26,13 @@ biome-lint:
 	$(BIOME_BASE_CMD) lint $(BIOME_CONFIG_PATH) $(FLAG)
 biome-all:
 	$(BIOME_BASE_CMD) check $(BIOME_CONFIG_PATH) $(FLAG)
+
+setup-pre-commit:
+	@if ! command -v pre-commit &> /dev/null; then \
+		echo "WARNING: 'pre-commit' is not installed. Please install it using: pip install pre-commit or brew install pre-commit"; \
+	else \
+		echo "pre-commit is installed! Proceeding with hook installation."; \
+		pre-commit install; \
+		pre-commit install --hook-type commit-msg; \
+		echo "pre-commit hooks have been successfully installed."; \
+	fi


### PR DESCRIPTION
pre-commit does not install commit-msg type hooks
by default. The make target will install all our
hook types automatically.
See https://pre-commit.com/#pre-commit-configyaml---top-level

Update CONTRIBUTING with new make target info.