### PR TITLE
CI: Add commit and biome lint to CI

### DIFF
--- a/.github/workflows/biome-lint.yml
+++ b/.github/workflows/biome-lint.yml
@@ -1,0 +1,24 @@
+name: Lint and Biome Check
+
+# Run the workflow when code is pushed or when a pull request is created
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  biome:
+    name: Run Biome
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checkout the repository so the workflow has access to the code
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Run the run-biome.sh script
+      - name: Run run-biome.sh
+        run: scripts/run-biome.sh

--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,114 @@
+name: commit lint
+
+on:
+    pull_request:
+        branches:
+        - main
+
+jobs:
+
+  commit_lint:
+    name: Run Lint Commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Commit Messages
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const excludedBotIds = [
+              49699333,  // dependabot[bot]
+            ];
+            const rules = [
+              {
+                pattern: /^[^\r]*$/,
+                error: "Commit message contains CRLF line breaks (only unix-style LF linebreaks are allowed)",
+              },
+              {
+                pattern: /^.+(\r?\n(\r?\n.*)*)?$/,
+                error: "Empty line between commit title and body is missing",
+              },
+              {
+                pattern: /^.{0,72}(?:\r?\n(?:(.{0,72})|(.*?([a-z]+:\/\/)?(([a-zA-Z0-9_]|-)+\.)+[a-z]{2,}(:\d+)?([a-zA-Z_0-9@:%\+.~\?&/=]|-)+).*?))*$/,
+                error: "Commit message lines are too long (maximum allowed is 72 characters, except for URLs)",
+              },
+              {
+                pattern: /^((?!^Merge branch )[\s\S])*$/,
+                error: "Commit is a git merge commit, use the rebase command instead",
+              },
+              {
+                pattern: /^\S.*?\S: .+/,
+                error: "Missing category in commit title (if this is a fix up of a previous commit, it should be squashed)",
+              },
+              {
+                pattern: /^\S.*?: [A-Z0-9]/,
+                error: "First word of commit after the subsystem is not capitalized",
+              },
+              {
+                pattern: /^.+[^.\n](\r?\n.*)*$/,
+                error: "Commit title ends in a period",
+              },
+              {
+                pattern: /^((?!Signed-off-by: )[\s\S])*$/,
+                error: "Commit body contains a Signed-off-by tag",
+              },
+            ];
+
+            const { repository, pull_request } = context.payload;
+
+            // NOTE: This maxes out at 250 commits. If this becomes a problem, see:
+            // https://octokit.github.io/rest.js/v18#pulls-list-commits
+            const opts = github.rest.pulls.listCommits.endpoint.merge({
+              owner: repository.owner.login,
+              repo: repository.name,
+              pull_number: pull_request.number,
+            });
+            const commits = await github.paginate(opts);
+
+            const errors = [];
+            for (const { sha, commit: { message }, author } of commits) {
+              if (author !== null && excludedBotIds.includes(author.id)) {
+                continue;
+              }
+              const commitErrors = [];
+              for (const { pattern, error } of rules) {
+                if (!pattern.test(message)) {
+                  commitErrors.push(error);
+                }
+              }
+              if (commitErrors.length > 0) {
+                const title = message.split("\n")[0];
+                errors.push([`${title} (${sha}):`, ...commitErrors].join("\n  "));
+              }
+            }
+
+            if (errors.length > 0) {
+              core.setFailed(`One or more of the commits in this PR do not match the code submission policy:\n\n${errors.join("\n")}`);
+            }
+
+      - name: Create PR comment on bad commit message
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        if: ${{ failure() && !github.event.pull_request.draft }}
+        with:
+          script: |
+            // If a comment already exists, skip
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const existingComment = comments.find(comment => comment.user.login === 'github-actions[bot]' && comment.body.includes('commit messages in this PR'));
+
+            if (existingComment) {
+              core.info('Preview comment already exists. Skipping...');
+              return;
+            }
+
+            const body = `### ❌ One or more of the commit messages in this PR do not match the nginx-hugo-theme [git guidelines](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md#git-guidelines), please check the CI job for more details on which commits were flagged and why.\nPlease do not close this PR and open another, instead modify your commit message(s) with [git commit --amend](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/changing-a-commit-message) and force push those changes to update this PR.`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body,
+            });


### PR DESCRIPTION
This will run against all branches pushed to
github and will block merges to main on failures.
