### PR TITLE
Theme: Toggle theme without passing boolean value

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -24,10 +24,9 @@
 
 
   <script>
-    
-    function useNewTheme(isNewTheme) {
-      localStorage.setItem("useNewTheme", `${isNewTheme}`);
 
+    const setTheme = (isNewTheme) => {
+      localStorage.setItem("useNewTheme", `${isNewTheme}`);
       // swap out v1 and v2 css style
       const v1cssIds = [
         "cssFA1",
@@ -39,11 +38,11 @@
         "css3",
         "css4",
         "css5",
-        "css6"
+        "css6",
       ];
 
       v1cssIds.forEach((cssId) => {
-        const element =  document.getElementById(cssId);
+        const element = document.getElementById(cssId);
         if (element !== null) {
           element.disabled = isNewTheme;
         }
@@ -51,23 +50,23 @@
 
       const v2cssIds = ["css7"];
       v2cssIds.forEach((cssId) => {
-        const element =  document.getElementById(cssId);
+        const element = document.getElementById(cssId);
         if (element !== null) {
           element.disabled = !isNewTheme;
         }
       });
 
       // swap out v1 and v2 elements
-      const v1ElementIds = ["sidebar", "footer", "toc"]
+      const v1ElementIds = ["sidebar", "footer", "toc"];
 
       v1ElementIds.forEach((elementId) => {
-        const element =  document.getElementById(elementId);
+        const element = document.getElementById(elementId);
         if (element !== null) {
           element.style.display = isNewTheme ? "none" : "";
         }
 
         const trustarc = document.getElementById("teconsent-v1");
-        if(trustarc) {
+        if (trustarc) {
           trustarc.id = isNewTheme ? "teconsent-v1" : "teconsent";
         }
       });
@@ -78,31 +77,51 @@
 
       document.querySelectorAll(".highlight").forEach((codeblock) => {
         codeblock.style.display = isNewTheme ? "none" : "";
-      })
+      });
 
       const mfElements = ['[data-mf="true"]'];
       mfElements.forEach((elementId) => {
-        document.querySelectorAll(elementId).forEach(
-            (element) => {
-              element.style.display = isNewTheme ? "" : "none";
+        document.querySelectorAll(elementId).forEach((element) => {
+          element.style.display = isNewTheme ? "" : "none";
 
-              const trustarc = document.getElementById("teconsent-v2");
-              if(trustarc) {
-                trustarc.id = isNewTheme ?  "teconsent" : "teconsent-v2";
-              }
-            }
-          );
+          const trustarc = document.getElementById("teconsent-v2");
+          if (trustarc) {
+            trustarc.id = isNewTheme ? "teconsent" : "teconsent-v2";
+          }
+        });
       });
 
       document.getElementById("body").style.visibility = "visible";
+    };
+
+    const toggleTheme = () => {
+      setTheme(!(localStorage.getItem("useNewTheme") === "true"));
+    };
+
+    // toggle theme aliases
+    const mf = toggleTheme;
+    const useNewTheme = toggleTheme;
+
+    document.addEventListener("DOMContentLoaded", () => {
+      setTheme(localStorage.getItem("useNewTheme") === "true");
+    });
+
+    function konami(callback) {
+      let kkeys = [];
+      // up,up,down,down,left,right,left,right,B,A
+      const konami = "38,38,40,40,37,39,37,39,66,65";
+      return (event) => {
+        kkeys.push(event.keyCode);
+        if (kkeys.toString().indexOf(konami) >= 0) {
+          callback(event);
+          kkeys = [];
+        }
+      };
     }
-
-    const mf = useNewTheme;
-    
-    document.addEventListener("DOMContentLoaded", function () {
-      useNewTheme(localStorage.getItem("useNewTheme") === "true");
-    })
-
+    const handler = konami(() => {
+      mf();
+    });
+    window.addEventListener("keydown", handler);
 
   </script>
 


### PR DESCRIPTION
Adds new toggleTheme function, along with aliases for existing mf and useNewTheme functions. These functions can now be called as toggles, instead of explicitly passing a boolean i.e. `mf()` or `useNewTheme()` or `toggleTheme()` will toggle themes. Add aliases for mf and useNewTheme for backwards compatability.

**Additional toggle options**
When we fully release, we should have a "preview new theme" front and centre, until then, to encourage internal testing, 
Add konami code to toggle (i.e. up,up,down,down,left,right,left,right,B,A) , from any page on the site, will toggle the theme

