### PR TITLE
Changed codeblock margin left to be non-zero if has comments

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -875,8 +875,12 @@ blockquote p:last-child {
 .highlight-mf {
   grid-column: 1 / -1 !important;
   position: relative;
-  margin-left: calc(var(--overflow-gutter-extension) / -2);
+  margin-left: 0;
   width: calc(100% + var(--overflow-gutter-extension));
+
+  &:has(.comment) {
+    margin-left: calc(var(--overflow-gutter-extension) / -1);
+  }
 
   code {
     font-weight: light;


### PR DESCRIPTION
### Proposed changes

Adjusted the margin of codeblocks without comments to be inline with text content.

Before:
![Screenshot 2025-03-04 at 8 16 39 AM](https://github.com/user-attachments/assets/d477988e-f484-4e61-ade3-231e1587f0ae)


After:
![Screenshot 2025-03-04 at 8 16 03 AM](https://github.com/user-attachments/assets/054113d6-dc6d-43b6-8800-dd651621e8d6)


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
