### PR TITLE
feat: Remove DocOps Writers from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @nginxinc/docs-engineering @nginxinc/nginx-docs
+* @nginxinc/docs-engineering 


### PR DESCRIPTION
### Proposed change

This commit removes the writing half of the DocOps team from CODEOWNERS. It is primarily engineers that iterate on the theme: this change ensures that writers are not engaged with any in-flight work prematurely.

User testing will be explicitly requested when new elements or functionality have reached an appropriate state of development.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
