### PR TITLE
Sidebar showing lines when there is a singular item

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -707,7 +707,10 @@ atomic-search-layout atomic-layout-section[section="search"] {
   position: relative;
 }
 
-.sidebar .sidebar-navigation .parent-collapsible-content::before {
+.sidebar
+  .sidebar-navigation
+  .parent-collapsible-content
+  li:not(:only-child)::before {
   content: "";
   position: absolute;
   border-left: black 1px solid;
@@ -717,7 +720,11 @@ atomic-search-layout atomic-layout-section[section="search"] {
 }
 
 /* First Sidebar Nav Horizontal Lines */
-.sidebar .sidebar-navigation .parent-collapsible-content .parent-box::before {
+.sidebar
+  .sidebar-navigation
+  .parent-collapsible-content
+  li:not(:only-child)
+  .parent-box::before {
   content: "";
   display: block;
   border-top: black 1px solid;


### PR DESCRIPTION
### Proposed changes

Fixes issue where there are vertical and horizontal lines showing when there is only a single item in the sidebar. 

Before:
<img width="1283" alt="Screenshot 2025-03-18 at 10 22 22 AM" src="https://github.com/user-attachments/assets/3a0472be-344e-4ce8-b299-32b3f37452f8" />


After:
<img width="1297" alt="Screenshot 2025-03-18 at 10 22 11 AM" src="https://github.com/user-attachments/assets/d1968d02-daf7-465d-bfc3-7039f2fe3db2" />


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
