### PR TITLE
Codeblock rendering incorrectly on old theme

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -1020,6 +1020,7 @@ blockquote.side-callout {
   border-top: 1px solid #cccccc;
   border-bottom: 1px solid #cccccc;
   overflow-x: scroll;
+  scrollbar-width: none;
 }
 
 .highlight-v2.single-line {

--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -3,7 +3,7 @@
 {{ $lines := split $result.Wrapped "\n" }}
 {{ $isSingleLine := eq (len $lines) 1 }}
 
-{{ if $isSingleLine  }}
+{{- if $isSingleLine  -}}
 <div class="code-block" data-mf="true" style="display: none;">
     <div class="code-header no-lang">
         <button onclick="copyToClipBoard(this)" data-id-codeblock="{{ $codeBlockId }}" class="code-copy-button" type="button">Copy</button>
@@ -12,25 +12,23 @@
         {{ $result.Wrapped }}
     </div>
 </div>
-{{ else }}
-
+{{- else -}}
 <div class="code-block" data-mf="true" style="display: none;">
-    {{ if and (ne .Type "") (ne .Type "none") }}
+    {{- if and (ne .Type "") (ne .Type "none") -}}
     <div class="code-header">
         <span class="code-type">{{ .Type }}</span>
         <button onclick="copyToClipBoard(this)" data-id-codeblock="{{ $codeBlockId }}" class="code-copy-button" type="button">Copy</button>
     </div>
-    {{ else }}
+    {{- else -}}
     <div class="code-header no-lang">
         <button onclick="copyToClipBoard(this)" data-id-codeblock="{{ $codeBlockId }}" class="code-copy-button" type="button">Copy</button>
     </div>
-    {{ end }}
+    {{- end -}}
     <div class="highlight-v2" id="{{ $codeBlockId }}">
         {{ $result.Wrapped }}
     </div>
 </div>
-
-{{ end }}
+{{- end -}}
 <div id="code-block-v1" data-mf="false">
 {{ $result.Wrapped }}
 </div>


### PR DESCRIPTION
### Proposed changes

Fixed issue with Codeblock rendering on old theme as seen on http://localhost:1313/nginx-app-protect-waf/v5/admin-guide/install/ locally

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
