### PR TITLE
Breadcrumbs on smaller resolutions

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -774,7 +774,12 @@ p {
 .breadcrumb ol {
   list-style: none;
   padding: 0;
-  display: flex;
+  display: block;
+
+  > * {
+    display: inline;
+    line-height: 25px;
+  }
 }
 
 .breadcrumb li:after {


### PR DESCRIPTION
### Proposed changes

Fixes how the breadcrumbs render on smaller resolutions so they are not squished. Below is on iPhone 11 Pro (375x812):

Before:
<img width="369" alt="Screenshot 2025-03-20 at 9 51 23 AM" src="https://github.com/user-attachments/assets/2b495ee6-9f4b-4a2a-b1fa-d6e61b033af1" />

After:
<img width="373" alt="Screenshot 2025-03-20 at 9 51 02 AM" src="https://github.com/user-attachments/assets/12a14751-7601-4c07-9e4f-abe7bb8b8e5c" />

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
