### PR TITLE
Set the grid row height to fit content instead of auto

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -255,6 +255,7 @@ nav {
   grid-column: 1 / -1;
   display: grid;
   grid-template-columns: var(--text-content-width-iphone-13) 1fr;
+  grid-auto-rows: max-content;
 }
 
 .text-content > :not(.wide) {


### PR DESCRIPTION
### Proposed changes

Closes https://github.com/nginxinc/docs-platform/issues/412

Before:
![Screenshot 2025-03-26 at 10 01 30 AM](https://github.com/user-attachments/assets/b6c8ac77-9828-450a-93de-628cac2598ed)


After:
![Screenshot 2025-03-26 at 10 01 18 AM](https://github.com/user-attachments/assets/e8fffacd-a0f0-4878-9b0b-47bf299fbfbd)


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
