### PR TITLE
Removed explicit height on sidebar

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -473,7 +473,6 @@ atomic-search-layout atomic-layout-section[section="search"] {
   width: 24rem;
   position: sticky;
   top: 0;
-  height: 100vh;
   margin-top: -1rem;
   padding-top: 1rem;
 }


### PR DESCRIPTION
### Proposed changes

Removes height of `100vh` from sidebar as it is making the page longer than needed as seen in a page such as http://localhost:1313/nginx-gateway-fabric/reference/technical-specifications/

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
