### PR TITLE
fix: Add a little extra codeblock lineheight

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -1106,6 +1106,7 @@ li .code-block {
   border-bottom: 1px solid #cccccc;
   overflow-x: scroll;
   scrollbar-width: none;
+  line-height: 1.3rem;
 }
 
 .highlight-v2.single-line {
@@ -1113,6 +1114,7 @@ li .code-block {
   align-items: center;
   border: 1px solid #cccccc;
   overflow-x: scroll;
+  line-height: 1;
 }
 
 .code-header {


### PR DESCRIPTION
Closes #405

Before:
<img width="420" alt="Screenshot 2025-03-28 at 9 44 24 AM" src="https://github.com/user-attachments/assets/c2e77512-9d9a-48e4-9545-2abbc3f5791e" />

After:
<img width="420" alt="Screenshot 2025-03-28 at 9 45 46 AM" src="https://github.com/user-attachments/assets/2e0f300a-da3a-4b67-949a-d1aa586a513d" />
