### PR TITLE
Add smooth scrolling to #links

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -59,6 +59,7 @@
   --flow-gap: 1rem;
 }
 
+/* reset */
 html,
 body,
 p,
@@ -110,6 +111,19 @@ h5,
 h6,
 .breadcrumb {
   font-weight: 500;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  scroll-margin-top: 1.5rem;
 }
 
 /* header */


### PR DESCRIPTION
Adds a little bit of vertical space when you click on a #link and a pure-CSS scroll animation, which is nice for when you click on heading links in the sidebar.