### PR TITLE
Throw error for highlight shortcode

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -60,6 +60,7 @@
   --color-shadow: #d2d2d2;
   --color-codeblock-border: #888;
   --color-codeblock-shadow: #e5e5e5;
+  --color-codeblock-highlight: #fffed9;
   --color-footer: #1d1d1d;
   --color-footer-text: #e2e2e2;
   --color-product-title: #8d8d8d;
@@ -1447,6 +1448,12 @@ ul .code-block {
   display: flex;
   list-style-type: none;
   padding: 0;
+}
+
+.highlight code .hl {
+  width: fit-content;
+  min-width: 100%;
+  background-color: var(--color-codeblock-highlight);
 }
 
 /* MARK: Images

--- a/exampleSite/content/test-product/code-blocks/code-blocks-highlighting.md
+++ b/exampleSite/content/test-product/code-blocks/code-blocks-highlighting.md
@@ -1,0 +1,45 @@
+---
+description: Code Blocks - highlighting
+title: Highlighting 
+weight: 200
+---
+
+{{<warning>}}
+There is an option to use the `highlight` shortcode from Hugo but we have disabled that feature as it is redundant to using ticks. All usage will throw an error in the Hugo build.
+{{</warning>}}
+
+## Example with highlighting one line
+```hcl {linenos=false,hl_lines=[16]}
+resource "azurerm_nginx_certificate" "cert1" {
+  name                     = "examplecert"
+  nginx_deployment_id      = azurerm_nginx_deployment.test.id
+  key_virtual_path         = "/src/cert/soservermekey.key"
+  certificate_virtual_path = "/src/cert/server.cert"
+  key_vault_secret_id      = azurerm_key_vault_certificate.test.secret_id
+}
+```
+
+## Example with highlighting multiple consecutive lines (2-4)
+```hcl {linenos=true,hl_lines="2-4"}
+resource "azurerm_nginx_certificate" "cert1" {
+  name                     = "examplecert"
+  nginx_deployment_id      = azurerm_nginx_deployment.test.id
+  key_virtual_path         = "/src/cert/soservermekey.key"
+  certificate_virtual_path = "/src/cert/server.cert"
+  key_vault_secret_id      = azurerm_key_vault_certificate.test.secret_id
+}
+```
+{{<call-out "side-callout" "Note">}}
+Values you can use for `hl_lines` are all non-zero positive integers. If you include a line number in `hl_lines` that does not exist (e.g. `16` in this example), it will highlight until the end.
+{{</call-out>}}
+
+## Example with highlighting multiple non-consecutive lines
+```hcl {linenos=true,hl_lines=[2,4,6]}
+resource "azurerm_nginx_certificate" "cert1" {
+  name                     = "examplecert"
+  nginx_deployment_id      = azurerm_nginx_deployment.test.id
+  key_virtual_path         = "/src/cert/soservermekey.key"
+  certificate_virtual_path = "/src/cert/server.cert"
+  key_vault_secret_id      = azurerm_key_vault_certificate.test.secret_id
+}
+```

--- a/layouts/shortcodes/highlight.html
+++ b/layouts/shortcodes/highlight.html
@@ -1,0 +1,1 @@
+{{ errorf "'<highlight></highlight>' is deprecated. Use codeblock shortcode (via triple ticks and setting 'hl_lines') instead."}}


### PR DESCRIPTION
### Proposed changes

Closes https://github.com/nginxinc/docs-platform/issues/463

Throws the following if `highlight` shortcode is used explicitly: 
<img width="913" alt="Screenshot 2025-04-16 at 12 07 53 PM" src="https://github.com/user-attachments/assets/5b21cab0-ddab-4f40-a53d-b876107e18e7" />

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
