### PR TITLE
Homepage: Add basic homepage styling

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -346,6 +346,93 @@ nav {
   }
 }
 
+/* MARK: Homepage
+*/
+
+.homepage {
+  margin: 0 2rem;
+
+  .homepage-heading {
+    grid-column: 1 / -1;
+    font-size: 1.5rem;
+    font-weight: 500;
+    margin: 2rem 0rem;
+  }
+
+  .homepage-section {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 500px));
+    gap: 1.5rem;
+    padding: 1rem;
+    justify-content: center;
+    max-width: 98rem;
+    margin: 0 auto;
+
+    .homepage-heading {
+      grid-column: 1 / -1;
+      margin: 1rem 0rem;
+    }
+  }
+
+  a {
+    color: var(--color-foreground);
+    text-decoration-color: var(--color-background);
+
+    &:hover {
+      text-decoration-color: var(--color-background);
+    }
+  }
+
+  /* Styling for items */
+  .homepage-item {
+    background: #fff;
+    border: 1px solid var(--color-codeblock-border);
+    box-shadow: 3px 3px 0px var(--color-shadow);
+    height: 7rem;
+    padding: 1rem 2rem 2rem 2rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    cursor: pointer;
+
+    &:hover {
+      box-shadow: 3px 3px 0px oklch(var(--color-brand) / 0.4);
+      text-decoration-color: var(--color-background);
+      border: 1px solid oklch(var(--color-brand) / 0.8);
+    }
+  }
+
+  .homepage-item-heading {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  .homepage-item-logo {
+    margin-right: 0.5rem;
+  }
+
+  .homepage-item-logo img {
+    height: 40px;
+    width: auto;
+    display: block;
+  }
+
+  .homepage-item-text {
+    font-size: 1.1rem;
+    font-weight: 600;
+    line-height: 1.2;
+    margin: 0;
+    padding: 0;
+    /* Hack to make text line-up with logos */
+    transform: translateY(-6px);
+  }
+
+  .homepage-item-content {
+    line-height: 1.5rem;
+  }
+}
+
 /* MARK: Main content
 */
 .docs-container * {
@@ -502,10 +589,6 @@ nav {
   .content-layout {
     grid-template-columns: 1fr var(--side-gutter-width);
   }
-}
-
-.main {
-  display: flex;
 }
 
 /* MARK: Coveo


### PR DESCRIPTION
These updates are across the theme and `documentation` https://github.com/nginx/documentation/pull/451.
The current logos are _awkward_ so I ended up doing some transform to get things to line up nicely.
This is a **for now** homepage. We will come back and do something better when we have more input on content.

Screenshots here show different widths, and a `:hover` example. The pointer is set to cursor also, it's just awkward to screenshot.

**Preview link https://frontdoor-test-docs.nginx.com/previews/docs/8de07aa/**


<img width="1623" alt="Screenshot 2025-04-24 at 15 47 27" src="https://github.com/user-attachments/assets/03f85452-e03d-4888-9566-e3080fd537bd" />

<img width="640" alt="Screenshot 2025-04-24 at 15 47 50" src="https://github.com/user-attachments/assets/60bef44a-da15-474e-b0c7-b1814b5bb91a" />

<img width="2318" alt="Screenshot 2025-04-24 at 15 47 37" src="https://github.com/user-attachments/assets/ea73614c-c7c7-4157-82cc-267e762fa9d2" />


<img width="555" alt="Screenshot 2025-04-24 at 15 47 59" src="https://github.com/user-attachments/assets/97528797-b19c-4b1d-8502-ef55740fe756" />
