### PR TITLE
Headers: Fix duplicate oldframe header links

### DIFF
--- a/exampleSite/content/test-product/everything.md
+++ b/exampleSite/content/test-product/everything.md
@@ -70,3 +70,8 @@ This won't render anything.
     <summary>Learn how to pin NGINX Plus to a specific version</summary>
     And this is the content on how to do so.
 </details>
+
+## [Heading with link](https://nginx.org/)
+
+This is some text, under a heading with a link.
+There was a bug, where if a heading had a link in it, it would get duplicated in old frame.

--- a/layouts/_default/_markup/render-heading.html
+++ b/layouts/_default/_markup/render-heading.html
@@ -7,7 +7,9 @@ id="{{ .Anchor | safeURL }}">
     </a>
 </div> 
 
-<a class="headerlink float-right" data-mf="true" style="display: none;" href="#{{ .Anchor | safeURL }}" title="{{ .Text | safeHTML }}">
+<div data-mf="true">
+<a class="headerlink float-right" href="#{{ .Anchor | safeURL }}" title="{{ .Text | safeHTML }}">
     {{ .Text | safeHTML }}
 </a>
+</div>
 </h{{ .Level }}>


### PR DESCRIPTION
This wraps the header generation in a div, since hugo seemed to remove the extra attribute in the anchor, including removing `data-mf` for some reason.

Newframe working as expected
<img width="734" alt="Screenshot 2025-04-29 at 15 18 24" src="https://github.com/user-attachments/assets/f6372ace-e562-4063-8992-07f8d2b4460e" />

Oldframe without duplicate
<img width="977" alt="Screenshot 2025-04-29 at 15 18 01" src="https://github.com/user-attachments/assets/2afd29e0-5a81-4788-afca-275945bde96f" />
