### PR TITLE
Style: Add styling to linked inline code blocks

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -1508,10 +1508,27 @@ code {
 /* Inline Code */
 code:not(pre code) {
   border: solid 1px #ccc;
-  border-radius: 4px;
+  border-radius: 0.25rem;
   padding: 0 0.25rem;
   background-color: #f9f9f9;
   font-size: 0.875rem;
+}
+
+/* Inline Code (link) */
+a code:not(pre code) {
+  border: solid 1px oklch(var(--color-brand) / 0.3);
+  border-bottom: solid 2px oklch(var(--color-brand) / 0.3);
+
+  /* transition: border 0.15s ease-in-out; */
+}
+
+a code:not(pre code):hover {
+  border: solid 1px oklch(var(--color-brand) / 0.8);
+  border-bottom: solid 2px oklch(var(--color-brand) / 0.8);
+}
+
+a:has(code:not(pre code)) {
+  text-decoration: none;
 }
 
 .highlight {


### PR DESCRIPTION
Note: leaving the transition commented out here because it causes a noticeable FOUC. Will need to find another solution, including for other links. It's a pretty subtle change.

### Proposed changes
Before:
<img width="857" alt="Screenshot 2025-04-30 at 2 48 41 PM" src="https://github.com/user-attachments/assets/0dc88ce4-e08d-444b-ad2a-6b0fca1f7dd3" />
After:
<img width="871" alt="Screenshot 2025-04-30 at 2 48 07 PM" src="https://github.com/user-attachments/assets/f0a3f599-730d-478c-9fe3-0bdcae3c1404" />

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
