### PR TITLE
Mainframe: Sidebar implemtation

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -794,6 +794,10 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
   font-size: 0.875rem;
 }
 
+.sidebar__container {
+  width: var(--sidebar-width);
+}
+
 .sidebar__container button {
   padding: 0.25rem 0.75rem;
 }
@@ -820,7 +824,7 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
   width: 100%;
   text-align: left;
   padding: 0.25rem 0.5rem;
-  border-radius: 5px;
+  border-radius: 5px 0 5px 0;
   font-weight: 500;
 
   &:hover {
@@ -849,13 +853,14 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
 
 .sidebar__toggle:has(.sidebar__chevron) {
   padding-left: .4rem;
+  margin-left: -1rem;
 }
 
 .sidebar__link {
   display: block;
   padding: 0.25rem 0.75rem;
-  margin: 2px 0.5rem 2px 0;
-  border-radius: 5px;
+  margin: 2px 0 2px 0;
+  border-radius: 5px 0 5px 0;
   color: oklch(0 0 0 / 0.75);
   text-decoration: none;
   transition: background-color 0.2s ease, color 0.2s ease;
@@ -870,7 +875,9 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
   color: oklch(var(--color-brand) / 1);
   background-color: oklch(var(--color-brand) / 0.1);
   font-weight: 600;
-  width: fit-content;
+  display: block; /* Make it stretch horizontally clearly */
+  width: auto; /* reset width clearly */
+  box-sizing: border-box;
 }
 
 .sidebar__toc {

--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -453,9 +453,20 @@ nav {
 .sidebar-layout {
   display: flex;
   flex-direction: column;
+  position: relative; /* required for absolute-positioned pseudo element */
   z-index: 2;
-  border-right: 1px solid var(--color-divider);
   min-height: 100vh;
+}
+
+/* this is the complete, corrected CSS you can directly copy/paste clearly: */
+.sidebar-layout::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: 0;
+  width: 1px;
+  background-color: var(--color-divider);
 }
 
 #searchbox {
@@ -810,6 +821,16 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
   text-align: left;
   padding: 0.25rem 0.5rem;
   border-radius: 5px;
+  font-weight: 500;
+
+  &:hover {
+    background-color: oklch(var(--color-brand) / 0.06);
+    color: oklch(var(--color-brand) / 1);
+  }
+}
+
+.sidebar__container button.sidebar__toggle--ancestor {
+  font-weight: 600;
 }
 
 .sidebar__chevron {
@@ -837,6 +858,12 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
   border-radius: 5px;
   color: oklch(0 0 0 / 0.75);
   text-decoration: none;
+  transition: background-color 0.2s ease, color 0.2s ease;
+
+  &:hover {
+    background-color: oklch(var(--color-brand) / 0.08);
+    color: oklch(var(--color-brand));
+  }
 }
 
 .sidebar__link--current {
@@ -848,10 +875,15 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
 
 .sidebar__toc {
   #TableOfContents {
-    padding: 0.25rem 0.75rem;
-    margin: 2px 0.5rem 2px 0;
-    border-radius: 5px;
+    padding: 0 0.75rem 0 0;
+    margin: 0.5rem 0.25rem 0.5rem 0.8rem;
+    border-left: 1px solid var(--color-divider);
     color: oklch(0 0 0 / 0.75);
+
+    a {
+      color: oklch(0 0 0 / 0.75);
+      text-decoration: none;
+    }
 
     &:empty {
       display: none;
@@ -859,6 +891,14 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
 
     li {
       padding: 0.25rem 0.75rem;
+    }
+
+    li:first-child {
+      padding-top: 0;
+    }
+
+    li:last-child {
+      padding-bottom: 0;
     }
   }
 }

--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -885,12 +885,14 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
     }
   }
 
-  .sidebar__link--current {
+  .sidebar__link--current,
+  .sidebar__toggle.sidebar__link--current {
     color: oklch(var(--color-brand) / 1);
     background-color: oklch(var(--color-brand) / 0.1);
     font-weight: 600;
-    display: block; /* Make it stretch horizontally clearly */
-    width: auto; /* reset width clearly */
+    display: flex;
+    justify-self: stretch;
+    width: auto;
     box-sizing: border-box;
   }
 
@@ -900,6 +902,10 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
       margin: 0.5rem 0.25rem 0.5rem 0.8rem;
       border-left: 1px solid var(--color-divider);
       color: oklch(0 0 0 / 0.75);
+
+      &[hidden] {
+        display: none;
+      }
 
       a {
         color: oklch(0 0 0 / 0.75);

--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -817,6 +817,7 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
 
   .sidebar__content {
     padding: 0.5rem 0 0.4rem 0;
+    margin-right: 0.25rem;
   }
 
   .sidebar__ul {
@@ -837,7 +838,7 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
     width: 100%;
     text-align: left;
     padding: 0.25rem 0.5rem;
-    border-radius: 5px 0 5px 0;
+    border-radius: 5px 0 0 5px;
     font-weight: 500;
     color: var(--color-foreground);
 
@@ -874,7 +875,7 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
     display: block;
     padding: 0.25rem 0.75rem;
     margin: 2px 0 2px 0;
-    border-radius: 5px 0 5px 0;
+    border-radius: 5px 0 0 5px;
     color: oklch(0 0 0 / 0.75);
     text-decoration: none;
     transition: background-color 0.2s ease, color 0.2s ease;
@@ -908,7 +909,6 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
       }
 
       a {
-        color: oklch(0 0 0 / 0.75);
         text-decoration: none;
       }
 
@@ -1604,6 +1604,31 @@ hr {
   stroke-linejoin: square;
   vertical-align: sub;
   margin: 0;
+}
+
+/* MARK: Accessibility
+*/
+
+.skip-link {
+  position: fixed;
+  top: 0;
+  left: 0;
+  background-color: var(--color-background);
+  color: var(--color-foreground);
+  padding: 1rem 1rem;
+  font-size: 1rem;
+  border: 2px solid var(--color-foreground);
+  z-index: 1000;
+  text-decoration: none;
+  border-radius: 0;
+  box-shadow: 3px 3px 0px var(--color-shadow);
+  opacity: 0;
+  pointer-events: none;
+}
+
+.skip-link:focus {
+  opacity: 1;
+  pointer-events: auto;
 }
 
 /* FILTHY HACKS BEGIN */

--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -576,6 +576,11 @@ nav {
   .content-layout .side-gutter {
     grid-column-start: 2;
   }
+
+  .navbar atomic-search-interface {
+    margin: 0;
+    display: block;
+  }
 }
 
 .list-page {
@@ -708,11 +713,6 @@ atomic-search-layout atomic-layout-section[section="search"] {
   z-index: 9999;
 }
 
-header atomic-search-interface {
-  /* Hide by default */
-  display: none;
-}
-
 body:not(:has(.main-layout)) header atomic-search-interface {
   /* Show on landing pages */
   display: block;
@@ -789,7 +789,7 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
   position: sticky;
   top: 0;
   margin-top: 0rem;
-  padding-top: 1rem;
+  padding-top: 1.5rem;
   align-items: start;
   overflow-y: auto;
   color: var(--color-foreground);

--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -281,6 +281,12 @@ header {
   }
 }
 
+main {
+  flex: 1;
+  min-width: 20rem;
+  margin: 0 2rem 2rem 1rem;
+}
+
 /* MARK: Footer
 */
 footer {
@@ -522,6 +528,10 @@ nav {
 
   .sidebar-layout {
     display: none;
+  }
+
+  main {
+    margin: 0 2rem 2rem 2rem;
   }
 }
 
@@ -770,6 +780,8 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
 */
 
 .sidebar {
+  --color-foreground: oklch(0 0 0 / 0.75);
+
   display: flex;
   flex-direction: column;
   width: 22rem;
@@ -780,143 +792,145 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
   padding-top: 1rem;
   align-items: start;
   overflow-y: auto;
-}
+  color: var(--color-foreground);
 
-/* Reset/Renormalize lists to remove default browser styling */
-.sidebar__container,
-.sidebar__container button,
-.sidebar__container ul,
-.sidebar__container li {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  font-weight: 400;
-  font-size: 0.875rem;
-}
-
-.sidebar__container {
-  width: var(--sidebar-width);
-}
-
-.sidebar__container button {
-  padding: 0.25rem 0.75rem;
-}
-
-.sidebar__content {
-  padding: 0.5rem 0 0.4rem 0;
-}
-
-.sidebar__ul {
-  padding-left: 0;
-}
-
-.sidebar__children {
-  padding-left: 1rem;
-}
-
-.sidebar__toggle {
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-  cursor: pointer;
-  background: none;
-  border: none;
-  width: 100%;
-  text-align: left;
-  padding: 0.25rem 0.5rem;
-  border-radius: 5px 0 5px 0;
-  font-weight: 500;
-
-  &:hover {
-    background-color: oklch(var(--color-brand) / 0.06);
-    color: oklch(var(--color-brand) / 1);
+  /* Reset/Renormalize lists to remove default browser styling */
+  .sidebar__container,
+  .sidebar__container button,
+  .sidebar__container ul,
+  .sidebar__container li {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    font-weight: 400;
+    font-size: 0.875rem;
   }
-}
 
-.sidebar__container button.sidebar__toggle--ancestor {
-  font-weight: 600;
-}
-
-.sidebar__chevron {
-  display: flex;
-  align-items: center;
-}
-
-.sidebar__chevron svg {
-  margin-right: -0.325rem;
-  stroke-width: 1.5;
-}
-
-.sidebar__chevron--open {
-  transform: rotate(90deg);
-}
-
-.sidebar__toggle:has(.sidebar__chevron) {
-  padding-left: .4rem;
-  margin-left: -1rem;
-}
-
-.sidebar__link {
-  display: block;
-  padding: 0.25rem 0.75rem;
-  margin: 2px 0 2px 0;
-  border-radius: 5px 0 5px 0;
-  color: oklch(0 0 0 / 0.75);
-  text-decoration: none;
-  transition: background-color 0.2s ease, color 0.2s ease;
-
-  &:hover {
-    background-color: oklch(var(--color-brand) / 0.08);
-    color: oklch(var(--color-brand));
+  .sidebar__container {
+    width: var(--sidebar-width);
   }
-}
 
-.sidebar__link--current {
-  color: oklch(var(--color-brand) / 1);
-  background-color: oklch(var(--color-brand) / 0.1);
-  font-weight: 600;
-  display: block; /* Make it stretch horizontally clearly */
-  width: auto; /* reset width clearly */
-  box-sizing: border-box;
-}
+  .sidebar__container button {
+    padding: 0.25rem 0.75rem;
+    justify-content: space-between;
+  }
 
-.sidebar__toc {
-  #TableOfContents {
-    padding: 0 0.75rem 0 0;
-    margin: 0.5rem 0.25rem 0.5rem 0.8rem;
-    border-left: 1px solid var(--color-divider);
+  .sidebar__content {
+    padding: 0.5rem 0 0.4rem 0;
+  }
+
+  .sidebar__ul {
+    padding-left: 0;
+  }
+
+  .sidebar__children {
+    padding-left: 1rem;
+  }
+
+  .sidebar__toggle {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    cursor: pointer;
+    background: none;
+    border: none;
+    width: 100%;
+    text-align: left;
+    padding: 0.25rem 0.5rem;
+    border-radius: 5px 0 5px 0;
+    font-weight: 500;
+    color: var(--color-foreground);
+
+    &:hover {
+      background-color: oklch(var(--color-brand) / 0.06);
+      color: oklch(var(--color-brand) / 1);
+    }
+  }
+
+  .sidebar__container button.sidebar__toggle--ancestor {
+    font-weight: 600;
+  }
+
+  .sidebar__chevron {
+    display: flex;
+    align-items: flex-end;
+  }
+
+  .sidebar__chevron svg {
+    stroke-width: 1.5;
+    width: 1rem;
+    height: 1rem;
+  }
+
+  .sidebar__chevron--open {
+    transform: rotate(90deg);
+  }
+
+  .sidebar__toggle:not(:has(.sidebar__chevron)) {
+    padding-left: 2rem;
+  }
+
+  .sidebar__link {
+    display: block;
+    padding: 0.25rem 0.75rem;
+    margin: 2px 0 2px 0;
+    border-radius: 5px 0 5px 0;
     color: oklch(0 0 0 / 0.75);
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
 
-    a {
+    &:hover {
+      background-color: oklch(var(--color-brand) / 0.08);
+      color: oklch(var(--color-brand));
+    }
+  }
+
+  .sidebar__link--current {
+    color: oklch(var(--color-brand) / 1);
+    background-color: oklch(var(--color-brand) / 0.1);
+    font-weight: 600;
+    display: block; /* Make it stretch horizontally clearly */
+    width: auto; /* reset width clearly */
+    box-sizing: border-box;
+  }
+
+  .sidebar__toc {
+    #TableOfContents {
+      padding: 0 0.75rem 0 0;
+      margin: 0.5rem 0.25rem 0.5rem 0.8rem;
+      border-left: 1px solid var(--color-divider);
       color: oklch(0 0 0 / 0.75);
-      text-decoration: none;
-    }
 
-    &:empty {
-      display: none;
-    }
+      a {
+        color: oklch(0 0 0 / 0.75);
+        text-decoration: none;
+      }
 
-    li {
-      padding: 0.25rem 0.75rem;
-    }
+      &:empty {
+        display: none;
+      }
 
-    li:first-child {
-      padding-top: 0;
-    }
+      li {
+        padding: 0.25rem 0.75rem;
+      }
 
-    li:last-child {
-      padding-bottom: 0;
+      li:first-child {
+        padding-top: 0;
+      }
+
+      ul ul li:first-child {
+        padding-top: 0.75rem;
+      }
+
+      li:last-child {
+        padding-bottom: 0;
+      }
     }
   }
 }
 
 /* MARK: Content
 */
-main {
-  flex: 1;
-  min-width: 20rem;
-  margin: 0 2rem 2rem 2rem;
-}
 
 p {
   margin: 0;
@@ -1575,8 +1589,8 @@ hr {
 }
 
 .lucide {
-  width: 1.5rem;
-  height: 1.5rem;
+  width: 3rem;
+  height: 3rem;
   stroke: currentColor;
   fill: none;
   stroke-width: 2;

--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -85,11 +85,11 @@
   --code-copy-icon-height: 1rem;
   --code-copy-icon-width: 1rem;
   --breadcrumb-max-height: 54px;
-  --sidebar-margin: 24px;
+  --sidebar-margin: 1.5rem;
   --sidebar-line-box-side-length: 8px;
   --sidebar-line-box-top: 6px;
   --sidebar-line-box-left: 12px;
-  --sidebar-width: 24rem;
+  --sidebar-width: 22rem;
   --sidebar-line-width: 11.5px;
   --side-gutter-width: 20rem;
   --table-top-bottom-spacing: 1rem;
@@ -453,8 +453,10 @@ nav {
 .sidebar-layout {
   display: flex;
   flex-direction: column;
-  position: relative;
   z-index: 2;
+  border-right: 1px solid var(--color-divider);
+  min-height: 100vh;
+  overflow-y: auto;
 }
 
 #searchbox {
@@ -710,36 +712,8 @@ body:not(:has(.main-layout)) header atomic-search-interface {
   }
 }
 
-/* MARK: Sidebar
+/* MARK: Product Selector
 */
-.sidebar {
-  display: flex;
-  flex-direction: column;
-  width: 24rem;
-  max-height: 100vh;
-  position: sticky;
-  top: 0;
-  margin-top: -1rem;
-  padding-top: 1rem;
-}
-
-.sidebar .product-selector-button {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  background-color: oklch(var(--color-brand));
-  color: var(--color-brand-100);
-  border: none;
-  font-size: 1.25rem;
-  width: 100%;
-  padding: 0.5rem 0.5rem 0.5rem 1rem; /* 1rem to vertically align with searchbar text */
-  cursor: pointer;
-}
-
-.sidebar .product-selector-button .selector-icon {
-  height: 24px;
-  width: 24px;
-}
 
 .product-selector {
   display: none;
@@ -782,273 +756,77 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
   font-size: 1rem;
 }
 
-/* Sidebar scroller */
-.sidebar .scrollbar-container {
-  width: 100%;
-  max-height: 100vh;
-  overflow: scroll;
-  scrollbar-gutter: stable;
-  scrollbar-width: none;
+/* MARK: Sidebar
+*/
+
+/* Reset/Renormalize lists to remove default browser styling */
+.sidebar__container,
+.sidebar__container button,
+.sidebar__container ul,
+.sidebar__container li {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  font-weight: 400;
+  font-size: 1rem;
 }
 
-.sidebar .scrollbar-container:hover {
-  overflow: auto;
+.sidebar__container button {
+  padding: 0.25rem 0.75rem;
 }
 
-.sidebar .sidebar-navigation {
-  margin-left: var(--sidebar-margin);
+.sidebar__content {
+  padding: 0.5rem 0 0.4rem 0;
 }
 
-/* removes the built in ul padding/margin */
-.sidebar .sidebar-navigation ul {
-  margin-left: 0;
+.sidebar__ul {
   padding-left: 0;
-  list-style-type: none;
 }
 
-.sidebar ul :not(.sidebar-navigation) ul {
-  padding-left: 16px;
+.sidebar__children {
+  padding-left: 1rem;
 }
 
-.sidebar .sidebar-navigation li {
-  margin-bottom: 16px;
-}
-
-.sidebar .sidebar-navigation a {
-  text-decoration: none;
-  color: black;
-}
-
-.sidebar .sidebar-navigation .collapsible-header {
+.sidebar__toggle {
   cursor: pointer;
-}
-
-.sidebar .sidebar-navigation .collapsible-content {
-  display: none;
-  position: relative;
-}
-
-.sidebar .sidebar-navigation .parent-box.opened,
-.sidebar .sidebar-navigation .box.opened {
-  display: none;
-}
-
-.toggle-checkbox:checked ~ .collapsible-header .parent-box.expand,
-.toggle-checkbox:checked ~ .collapsible-header .box.expand {
-  display: none;
-}
-
-.toggle-checkbox:checked ~ .collapsible-content {
-  display: block;
-}
-
-.toggle-checkbox:checked ~ .collapsible-header .parent-box.opened {
-  display: inline-block;
-}
-
-.toggle-checkbox:checked ~ .collapsible-header .box.opened {
-  display: block;
-}
-
-/* Every other Sidebar Partial Vertical Line */
-.toggle-checkbox:checked ~ .collapsible-content::before {
-  content: "";
-  position: absolute;
-  border-left: black 1px solid;
-  left: -8.5px;
-  top: -22.5px;
-  height: calc(100% + 13.5px);
-}
-
-/* Every other Sidebar Partial Horizontal Lines */
-.toggle-checkbox:checked ~ .collapsible-content li {
-  position: relative;
-}
-
-.collapsible-content .box::after {
-  content: "";
-  position: absolute;
-  border-top: black 1px solid;
-  left: -11.5px;
-  width: var(--sidebar-line-width);
-  top: 50%;
-}
-
-.collapsible-content .opened::after {
-  content: "";
-  position: absolute;
-  border-top: black 1px solid;
-  left: -12.5px;
-  width: var(--sidebar-line-width);
-  top: 50%;
-}
-
-.collapsible-content .box-link::after {
-  content: "";
-  position: absolute;
-  border-top: black 1px solid;
-  left: -11.5px;
-  width: var(--sidebar-line-width);
-  top: 50%;
-}
-
-.selected {
-  font-weight: 800;
-}
-
-.sidebar .sidebar-navigation li:first-child {
-  margin-top: 16px;
-}
-
-.sidebar .sidebar-navigation ul li .parent-box-link {
-  content: "";
-  background-color: black;
-  position: absolute;
-  width: 1px;
-  height: var(--sidebar-line-box-side-length);
-  margin-top: var(--sidebar-line-box-top);
-  left: calc(0px - var(--sidebar-line-box-left));
-}
-
-.sidebar .sidebar-navigation ul li .box-link {
-  content: "";
-  background-color: black;
-  position: absolute;
-  width: 1px;
-  height: var(--sidebar-line-box-side-length);
-  margin-top: var(--sidebar-line-box-top);
-  left: var(--sidebar-line-box-left);
-}
-
-.sidebar .sidebar-navigation ul li .parent-box {
-  content: "";
-  display: inline-block;
-  width: var(--sidebar-line-box-side-length);
-  height: var(--sidebar-line-box-side-length);
-  vertical-align: middle;
-  margin-left: -12px;
-  margin-top: -4px;
-}
-
-.sidebar .sidebar-navigation ul li .box {
-  content: "";
-  position: absolute;
-  width: var(--sidebar-line-box-side-length);
-  height: var(--sidebar-line-box-side-length);
-  margin-top: var(--sidebar-line-box-top);
-  left: var(--sidebar-line-box-left);
-}
-
-.sidebar .sidebar-navigation ul li .expand {
-  background-color: black;
-}
-
-.sidebar .sidebar-navigation ul li .opened {
-  border: black 1px solid;
-}
-
-.sidebar .sidebar-navigation ul li .current {
-  background-color: oklch(var(--color-brand));
-}
-
-.sidebar .sidebar-navigation ul li .partial-box {
-  margin-left: -24px;
-}
-
-.sidebar .sidebar-navigation ul li .partial {
-  margin-top: 0;
-  top: 5px;
-  left: -13px;
-}
-
-/* First Sidebar Nav Vertical Line */
-.sidebar .sidebar-navigation .parent-collapsible-content {
-  position: relative;
-}
-
-.sidebar .sidebar-navigation .parent-collapsible-content:first-child::before {
-  content: "";
-  position: absolute;
-  border-left: black 1px solid;
-  left: -24px;
-  top: 10px;
-  height: calc(100% - 9px - 10px);
-}
-
-.sidebar
-  .sidebar-navigation
-  .parent-collapsible-content
-  li:not(:only-child)
-  a
-  + :not(:has(#TableOfContents))
-  li::before {
+  background: none;
   border: none;
+  width: 100%;
+  text-align: left;
+  padding: 0.25rem 0.75rem;
+  border-radius: 5px;
 }
 
-/* First Sidebar Nav Horizontal Lines */
-.sidebar
-  .sidebar-navigation
-  .parent-collapsible-content
-  li:not(:only-child)
-  .parent-box::before {
-  content: "";
+.sidebar__link {
   display: block;
-  border-top: black 1px solid;
-  margin-left: -12px;
-  margin-top: 50%;
-  width: var(--sidebar-line-width);
+  padding: 0.25rem 0.75rem;
+  margin: 2px 0.5rem 2px 0;
+  border-radius: 5px;
+  color: oklch(0 0 0 / 0.75);
+  text-decoration: none;
 }
 
-.parent-collapsible-content .parent-box-link::after {
-  content: "";
-  position: absolute;
-  border-top: black 1px solid;
-  left: -11.5px;
-  width: var(--sidebar-line-width);
-  top: 50%;
+.sidebar__link--current {
+  color: oklch(var(--color-brand) / 1);
+  background-color: oklch(var(--color-brand) / 0.1);
+  font-weight: 600;
 }
 
-.row {
-  display: flex;
-  flex-wrap: nowrap;
-  align-items: flex-start;
-}
+.sidebar__toc {
+  #TableOfContents {
+    padding: 0.25rem 0.75rem;
+    margin: 2px 0.5rem 2px 0;
+    border-radius: 5px;
+    color: oklch(0 0 0 / 0.75);
 
-/* Details/Summary */
-details summary {
-  color: oklch(var(--color-brand));
-  transition: text-decoration-color 0.15s ease-in-out;
-  text-decoration: underline;
-  text-decoration-color: oklch(var(--color-brand) / 0.3);
+    &:empty {
+      display: none;
+    }
 
-  & ~ * {
-    margin-top: 1rem;
+    li {
+      padding: 0.25rem 0.75rem;
+    }
   }
-}
-
-details summary:hover {
-  text-decoration-color: oklch(var(--color-brand) / 0.8);
-}
-
-details:hover {
-  cursor: pointer;
-}
-
-/* Table of Contents */
-#TableOfContents {
-  /* Close all TOC on sidebar */
-  display: none;
-}
-
-.current ~ nav,
-.collapsible-content li ul li:has(.current) > nav {
-  /* Open TOC for current page */
-  display: block !important;
-}
-
-#TableOfContents li:not(:empty) {
-  position: relative;
-  list-style: square;
 }
 
 /* MARK: Content

--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -1595,8 +1595,8 @@ hr {
 }
 
 .lucide {
-  width: 3rem;
-  height: 3rem;
+  width: 1.5rem;
+  height: 1.5rem;
   stroke: currentColor;
   fill: none;
   stroke-width: 2;

--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -456,7 +456,6 @@ nav {
   z-index: 2;
   border-right: 1px solid var(--color-divider);
   min-height: 100vh;
-  overflow-y: auto;
 }
 
 #searchbox {
@@ -758,6 +757,19 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
 
 /* MARK: Sidebar
 */
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  width: 22rem;
+  max-height: 100vh;
+  position: sticky;
+  top: 0;
+  margin-top: 0rem;
+  padding-top: 1rem;
+  align-items: start;
+  overflow-y: auto;
+}
 
 /* Reset/Renormalize lists to remove default browser styling */
 .sidebar__container,

--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -768,7 +768,7 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
   padding: 0;
   list-style: none;
   font-weight: 400;
-  font-size: 1rem;
+  font-size: 0.875rem;
 }
 
 .sidebar__container button {
@@ -788,13 +788,34 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
 }
 
 .sidebar__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
   cursor: pointer;
   background: none;
   border: none;
   width: 100%;
   text-align: left;
-  padding: 0.25rem 0.75rem;
+  padding: 0.25rem 0.5rem;
   border-radius: 5px;
+}
+
+.sidebar__chevron {
+  display: flex;
+  align-items: center;
+}
+
+.sidebar__chevron svg {
+  margin-right: -0.325rem;
+  stroke-width: 1.5;
+}
+
+.sidebar__chevron--open {
+  transform: rotate(90deg);
+}
+
+.sidebar__toggle:has(.sidebar__chevron) {
+  padding-left: .4rem;
 }
 
 .sidebar__link {
@@ -810,6 +831,7 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
   color: oklch(var(--color-brand) / 1);
   background-color: oklch(var(--color-brand) / 0.1);
   font-weight: 600;
+  width: fit-content;
 }
 
 .sidebar__toc {

--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -725,13 +725,6 @@ body:not(:has(.main-layout)) header atomic-search-interface {
   }
 }
 
-@media (max-width: 1023px) {
-  /* Show on search page with facet if it is hidden */
-  body:has(atomic-search-layout) header atomic-search-interface {
-    display: block;
-  }
-}
-
 /* MARK: Product Selector
 */
 

--- a/assets/js/coveo.js
+++ b/assets/js/coveo.js
@@ -53,22 +53,6 @@ async function atomicCoveo() {
       },
     });
     await searchPageInterface.executeFirstSearch();
-  } else {
-    if (sidebar) {
-      await searchBarSidebar.initialize({
-        accessToken: token,
-        organizationId: org_id,
-        analytics: { analyticsMode: 'legacy' },
-        preprocessRequest: (request, clientOrigin, metadata) => {
-          const body = JSON.parse(request.body);
-          body.q = `<@- ${body.q} -@>`;
-          request.body = JSON.stringify(body);
-
-          return request;
-        },
-      });
-      await searchBarSidebar.executeFirstSearch();
-    }
   }
 
   /* Initialize the header searchbar*/

--- a/assets/js/sidebar-v2.js
+++ b/assets/js/sidebar-v2.js
@@ -1,17 +1,14 @@
 document.addEventListener('DOMContentLoaded', () => {
-  function expandToCurrentPage() {
-    const currentPage = document.getElementById('current-page');
-    if (currentPage) {
-      let parentLabel = currentPage.closest('li');
-      while (parentLabel) {
-        const checkbox = parentLabel.querySelector('.toggle-checkbox');
-        if (checkbox) {
-          checkbox.checked = true;
-        }
-        parentLabel = parentLabel.closest('ul').closest('li');
-      }
-    }
-  }
+  const toggles = document.querySelectorAll('.sidebar__toggle');
 
-  expandToCurrentPage();
+  toggles.forEach((toggle) => {
+    const parent = toggle.closest('li.sidebar__section');
+    const children = parent.querySelector('.sidebar__children');
+
+    toggle.addEventListener('click', () => {
+      const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', !isExpanded);
+      children.hidden = isExpanded;
+    });
+  });
 });

--- a/assets/js/sidebar-v2.js
+++ b/assets/js/sidebar-v2.js
@@ -16,3 +16,19 @@ document.addEventListener('click', (e) => {
     }
   }
 });
+
+document.addEventListener('DOMContentLoaded', () => {
+  const sidebar = document.querySelector('.sidebar__ul');
+
+  if (!sidebar) return;
+
+  const activeLink = sidebar.querySelector('.sidebar__link--current');
+
+  if (activeLink) {
+    activeLink.scrollIntoView({
+      behavior: 'auto',
+      block: 'center',
+      inline: 'nearest',
+    });
+  }
+});

--- a/assets/js/sidebar-v2.js
+++ b/assets/js/sidebar-v2.js
@@ -5,15 +5,12 @@ document.addEventListener('click', (e) => {
     const expanded = toggle.getAttribute('aria-expanded') === 'true';
     const panel = document.getElementById(toggle.getAttribute('aria-controls'));
 
-    // Toggle the expanded state
     toggle.setAttribute('aria-expanded', String(!expanded));
 
-    // Toggle visibility of the content
     if (panel) {
       panel.hidden = expanded;
     }
 
-    // Toggle chevron direction class
     if (chevron) {
       chevron.classList.toggle('sidebar__chevron--open', !expanded);
     }

--- a/assets/js/sidebar-v2.js
+++ b/assets/js/sidebar-v2.js
@@ -1,14 +1,21 @@
-document.addEventListener('DOMContentLoaded', () => {
-  const toggles = document.querySelectorAll('.sidebar__toggle');
+document.addEventListener('click', (e) => {
+  const toggle = e.target.closest('.sidebar__toggle');
+  if (toggle) {
+    const chevron = toggle.querySelector('.sidebar__chevron');
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    const panel = document.getElementById(toggle.getAttribute('aria-controls'));
 
-  toggles.forEach((toggle) => {
-    const parent = toggle.closest('li.sidebar__section');
-    const children = parent.querySelector('.sidebar__children');
+    // Toggle the expanded state
+    toggle.setAttribute('aria-expanded', String(!expanded));
 
-    toggle.addEventListener('click', () => {
-      const isExpanded = toggle.getAttribute('aria-expanded') === 'true';
-      toggle.setAttribute('aria-expanded', !isExpanded);
-      children.hidden = isExpanded;
-    });
-  });
+    // Toggle visibility of the content
+    if (panel) {
+      panel.hidden = expanded;
+    }
+
+    // Toggle chevron direction class
+    if (chevron) {
+      chevron.classList.toggle('sidebar__chevron--open', !expanded);
+    }
+  }
 });

--- a/exampleSite/content/test-product/feather/_index.md
+++ b/exampleSite/content/test-product/feather/_index.md
@@ -4,3 +4,5 @@ title: Feather
 weight: 300
 toc: true
 ---
+
+Hello!

--- a/exampleSite/content/test-product/sidebar/_index.md
+++ b/exampleSite/content/test-product/sidebar/_index.md
@@ -1,0 +1,10 @@
+---
+description: Sidebar
+title: Sidebar
+---
+
+This is the overview page for level 0. The root. This is an `_index.md` file.
+
+Because there is some content in this `_index.md` file, it should be displayed.
+
+If it were empty, we'd skip this and go straight to the first populated content in this tree.

--- a/exampleSite/content/test-product/sidebar/nesting-1a/_index.md
+++ b/exampleSite/content/test-product/sidebar/nesting-1a/_index.md
@@ -1,0 +1,7 @@
+---
+description: Nesting-1a
+title: Nesting-1a
+---
+
+
+1a only has content at this level. This is an `_index.md` file.

--- a/exampleSite/content/test-product/sidebar/nesting-1b/_index.md
+++ b/exampleSite/content/test-product/sidebar/nesting-1b/_index.md
@@ -1,0 +1,4 @@
+---
+description: Nesting-1b
+title: Nesting-1b
+---

--- a/exampleSite/content/test-product/sidebar/nesting-1b/nesting-2/_index.md
+++ b/exampleSite/content/test-product/sidebar/nesting-1b/nesting-2/_index.md
@@ -1,0 +1,4 @@
+---
+description: Nesting-2
+title: Nesting-2
+---

--- a/exampleSite/content/test-product/sidebar/nesting-1b/nesting-2/nesting-2-1.md
+++ b/exampleSite/content/test-product/sidebar/nesting-1b/nesting-2/nesting-2-1.md
@@ -1,0 +1,6 @@
+---
+description: Nesting-2-content-1
+title: Nesting-2-content-1
+---
+
+This is some content in Nesting-2-content-1

--- a/exampleSite/content/test-product/sidebar/nesting-1b/nesting-2/nesting-2-2.md
+++ b/exampleSite/content/test-product/sidebar/nesting-1b/nesting-2/nesting-2-2.md
@@ -1,0 +1,87 @@
+---
+description: Nesting-2-content-2
+title: Nesting-2-content-2
+---
+
+This is some content in Nesting-2-content-2.
+
+This is long enough to push headers outside of the normal viewport.
+
+
+## Testing some headings for the toc 1
+
+Some content
+
+
+## Testing some headings for the toc 2
+
+Once upon a time in the Technicolor Cloud Kingdom of Serverlandia, a joyful wind blew across the binary meadows, whispering tales of a mystical creature named nginx (pronounced "engine-x" by the locals and "wizard-swoosh" by the jellyfish). It wasn’t a dragon, a unicorn, or a sentient avocado—it was something far more magical: a hyper-fast, ever-smiling web server with the personality of a golden retriever and the efficiency of 10,000 caffeinated squirrels.
+
+Every morning, nginx would wake up with a cheerful beep-boop, stretch its configuration files, and greet the sun with a reverse proxy pirouette. Birds chirped in HTTP headers, and butterflies fluttered by on compressed gzip wings. Wherever nginx went, latency dropped to zero and 404 errors turned into motivational quotes.
+
+“Your content is just loading its potential!” they would say, bringing tears to the eyes of developers and hummingbirds alike.
+
+The townsfolk of Serverlandia adored nginx. They built shrines out of old USB cables and offered it snacks made of finely spun JSON. Even the databases—who were notoriously grumpy—would sing praises of nginx’s load balancing lullabies. Apache, the wise old monk of the hills, once tried to challenge nginx to a duel of requests-per-second, but halfway through the contest he just sighed, gave nginx a hug, and invited it to tea.
+
+At night, nginx would tuck in the children of the village by wrapping their bedtime stories in TLS encryption and caching their dreams for extra speed. Unicorns danced across CDN rainbows, singing songs about scalability and uptime. The moon itself would giggle as nginx gracefully handled a billion concurrent connections while baking cookies shaped like serverless functions.
+
+Even the grumpy firewall trolls came around, offering friendly port forwards and warm handshakes. Life was good. Load times were fast. The air smelled faintly of peppermint and perfectly formed XML.
+
+And thus, in a land where packets flowed like chocolate rivers and downtime was just a scary campfire story, nginx reigned supreme—not with power, but with kindness, balance, and beautifully efficient asynchronous processing.
+
+Everyone lived happily ever after, behind seven layers of security and a content delivery network that sparkled in the sky.
+
+
+## Testing some headings for the toc 3
+
+Once upon a time in the Technicolor Cloud Kingdom of Serverlandia, a joyful wind blew across the binary meadows, whispering tales of a mystical creature named nginx (pronounced "engine-x" by the locals and "wizard-swoosh" by the jellyfish). It wasn’t a dragon, a unicorn, or a sentient avocado—it was something far more magical: a hyper-fast, ever-smiling web server with the personality of a golden retriever and the efficiency of 10,000 caffeinated squirrels.
+
+Every morning, nginx would wake up with a cheerful beep-boop, stretch its configuration files, and greet the sun with a reverse proxy pirouette. Birds chirped in HTTP headers, and butterflies fluttered by on compressed gzip wings. Wherever nginx went, latency dropped to zero and 404 errors turned into motivational quotes.
+
+“Your content is just loading its potential!” they would say, bringing tears to the eyes of developers and hummingbirds alike.
+
+The townsfolk of Serverlandia adored nginx. They built shrines out of old USB cables and offered it snacks made of finely spun JSON. Even the databases—who were notoriously grumpy—would sing praises of nginx’s load balancing lullabies. Apache, the wise old monk of the hills, once tried to challenge nginx to a duel of requests-per-second, but halfway through the contest he just sighed, gave nginx a hug, and invited it to tea.
+
+At night, nginx would tuck in the children of the village by wrapping their bedtime stories in TLS encryption and caching their dreams for extra speed. Unicorns danced across CDN rainbows, singing songs about scalability and uptime. The moon itself would giggle as nginx gracefully handled a billion concurrent connections while baking cookies shaped like serverless functions.
+
+Even the grumpy firewall trolls came around, offering friendly port forwards and warm handshakes. Life was good. Load times were fast. The air smelled faintly of peppermint and perfectly formed XML.
+
+And thus, in a land where packets flowed like chocolate rivers and downtime was just a scary campfire story, nginx reigned supreme—not with power, but with kindness, balance, and beautifully efficient asynchronous processing.
+
+Everyone lived happily ever after, behind seven layers of security and a content delivery network that sparkled in the sky.
+
+## Testing some headings for the toc 4
+
+Once upon a time in the Technicolor Cloud Kingdom of Serverlandia, a joyful wind blew across the binary meadows, whispering tales of a mystical creature named nginx (pronounced "engine-x" by the locals and "wizard-swoosh" by the jellyfish). It wasn’t a dragon, a unicorn, or a sentient avocado—it was something far more magical: a hyper-fast, ever-smiling web server with the personality of a golden retriever and the efficiency of 10,000 caffeinated squirrels.
+
+Every morning, nginx would wake up with a cheerful beep-boop, stretch its configuration files, and greet the sun with a reverse proxy pirouette. Birds chirped in HTTP headers, and butterflies fluttered by on compressed gzip wings. Wherever nginx went, latency dropped to zero and 404 errors turned into motivational quotes.
+
+“Your content is just loading its potential!” they would say, bringing tears to the eyes of developers and hummingbirds alike.
+
+The townsfolk of Serverlandia adored nginx. They built shrines out of old USB cables and offered it snacks made of finely spun JSON. Even the databases—who were notoriously grumpy—would sing praises of nginx’s load balancing lullabies. Apache, the wise old monk of the hills, once tried to challenge nginx to a duel of requests-per-second, but halfway through the contest he just sighed, gave nginx a hug, and invited it to tea.
+
+At night, nginx would tuck in the children of the village by wrapping their bedtime stories in TLS encryption and caching their dreams for extra speed. Unicorns danced across CDN rainbows, singing songs about scalability and uptime. The moon itself would giggle as nginx gracefully handled a billion concurrent connections while baking cookies shaped like serverless functions.
+
+Even the grumpy firewall trolls came around, offering friendly port forwards and warm handshakes. Life was good. Load times were fast. The air smelled faintly of peppermint and perfectly formed XML.
+
+And thus, in a land where packets flowed like chocolate rivers and downtime was just a scary campfire story, nginx reigned supreme—not with power, but with kindness, balance, and beautifully efficient asynchronous processing.
+
+Everyone lived happily ever after, behind seven layers of security and a content delivery network that sparkled in the sky.
+
+## Testing some headings for the toc 5
+
+Once upon a time in the Technicolor Cloud Kingdom of Serverlandia, a joyful wind blew across the binary meadows, whispering tales of a mystical creature named nginx (pronounced "engine-x" by the locals and "wizard-swoosh" by the jellyfish). It wasn’t a dragon, a unicorn, or a sentient avocado—it was something far more magical: a hyper-fast, ever-smiling web server with the personality of a golden retriever and the efficiency of 10,000 caffeinated squirrels.
+
+Every morning, nginx would wake up with a cheerful beep-boop, stretch its configuration files, and greet the sun with a reverse proxy pirouette. Birds chirped in HTTP headers, and butterflies fluttered by on compressed gzip wings. Wherever nginx went, latency dropped to zero and 404 errors turned into motivational quotes.
+
+“Your content is just loading its potential!” they would say, bringing tears to the eyes of developers and hummingbirds alike.
+
+The townsfolk of Serverlandia adored nginx. They built shrines out of old USB cables and offered it snacks made of finely spun JSON. Even the databases—who were notoriously grumpy—would sing praises of nginx’s load balancing lullabies. Apache, the wise old monk of the hills, once tried to challenge nginx to a duel of requests-per-second, but halfway through the contest he just sighed, gave nginx a hug, and invited it to tea.
+
+At night, nginx would tuck in the children of the village by wrapping their bedtime stories in TLS encryption and caching their dreams for extra speed. Unicorns danced across CDN rainbows, singing songs about scalability and uptime. The moon itself would giggle as nginx gracefully handled a billion concurrent connections while baking cookies shaped like serverless functions.
+
+Even the grumpy firewall trolls came around, offering friendly port forwards and warm handshakes. Life was good. Load times were fast. The air smelled faintly of peppermint and perfectly formed XML.
+
+And thus, in a land where packets flowed like chocolate rivers and downtime was just a scary campfire story, nginx reigned supreme—not with power, but with kindness, balance, and beautifully efficient asynchronous processing.
+
+Everyone lived happily ever after, behind seven layers of security and a content delivery network that sparkled in the sky.

--- a/exampleSite/content/test-product/sidebar/nesting-1b/nesting-2/nesting-3/_index.md
+++ b/exampleSite/content/test-product/sidebar/nesting-1b/nesting-2/nesting-3/_index.md
@@ -1,0 +1,4 @@
+---
+description: Nesting-3
+title: Nesting-3
+---

--- a/exampleSite/content/test-product/sidebar/nesting-1c/_index.md
+++ b/exampleSite/content/test-product/sidebar/nesting-1c/_index.md
@@ -1,0 +1,4 @@
+---
+description: Nesting-1c
+title: Nesting-1c
+---

--- a/exampleSite/content/test-product/sidebar/nesting-1c/nesting-2/_index.md
+++ b/exampleSite/content/test-product/sidebar/nesting-1c/nesting-2/_index.md
@@ -1,0 +1,4 @@
+---
+description: Nesting-2
+title: Nesting-2
+---

--- a/exampleSite/content/test-product/sidebar/nesting-1c/nesting-2/nesting-2-1.md
+++ b/exampleSite/content/test-product/sidebar/nesting-1c/nesting-2/nesting-2-1.md
@@ -1,0 +1,6 @@
+---
+description: Nesting-2-content-1
+title: Nesting-2-content-1
+---
+
+This is some content in Nesting-2-content-1

--- a/exampleSite/content/test-product/sidebar/nesting-1c/nesting-2/nesting-2-2.md
+++ b/exampleSite/content/test-product/sidebar/nesting-1c/nesting-2/nesting-2-2.md
@@ -1,0 +1,87 @@
+---
+description: Nesting-2-content-2
+title: Nesting-2-content-2
+---
+
+This is some content in Nesting-2-content-2.
+
+This is long enough to push headers outside of the normal viewport.
+
+
+## Testing some headings for the toc 1
+
+Some content
+
+
+## Testing some headings for the toc 2
+
+Once upon a time in the Technicolor Cloud Kingdom of Serverlandia, a joyful wind blew across the binary meadows, whispering tales of a mystical creature named nginx (pronounced "engine-x" by the locals and "wizard-swoosh" by the jellyfish). It wasn’t a dragon, a unicorn, or a sentient avocado—it was something far more magical: a hyper-fast, ever-smiling web server with the personality of a golden retriever and the efficiency of 10,000 caffeinated squirrels.
+
+Every morning, nginx would wake up with a cheerful beep-boop, stretch its configuration files, and greet the sun with a reverse proxy pirouette. Birds chirped in HTTP headers, and butterflies fluttered by on compressed gzip wings. Wherever nginx went, latency dropped to zero and 404 errors turned into motivational quotes.
+
+“Your content is just loading its potential!” they would say, bringing tears to the eyes of developers and hummingbirds alike.
+
+The townsfolk of Serverlandia adored nginx. They built shrines out of old USB cables and offered it snacks made of finely spun JSON. Even the databases—who were notoriously grumpy—would sing praises of nginx’s load balancing lullabies. Apache, the wise old monk of the hills, once tried to challenge nginx to a duel of requests-per-second, but halfway through the contest he just sighed, gave nginx a hug, and invited it to tea.
+
+At night, nginx would tuck in the children of the village by wrapping their bedtime stories in TLS encryption and caching their dreams for extra speed. Unicorns danced across CDN rainbows, singing songs about scalability and uptime. The moon itself would giggle as nginx gracefully handled a billion concurrent connections while baking cookies shaped like serverless functions.
+
+Even the grumpy firewall trolls came around, offering friendly port forwards and warm handshakes. Life was good. Load times were fast. The air smelled faintly of peppermint and perfectly formed XML.
+
+And thus, in a land where packets flowed like chocolate rivers and downtime was just a scary campfire story, nginx reigned supreme—not with power, but with kindness, balance, and beautifully efficient asynchronous processing.
+
+Everyone lived happily ever after, behind seven layers of security and a content delivery network that sparkled in the sky.
+
+
+## Testing some headings for the toc 3
+
+Once upon a time in the Technicolor Cloud Kingdom of Serverlandia, a joyful wind blew across the binary meadows, whispering tales of a mystical creature named nginx (pronounced "engine-x" by the locals and "wizard-swoosh" by the jellyfish). It wasn’t a dragon, a unicorn, or a sentient avocado—it was something far more magical: a hyper-fast, ever-smiling web server with the personality of a golden retriever and the efficiency of 10,000 caffeinated squirrels.
+
+Every morning, nginx would wake up with a cheerful beep-boop, stretch its configuration files, and greet the sun with a reverse proxy pirouette. Birds chirped in HTTP headers, and butterflies fluttered by on compressed gzip wings. Wherever nginx went, latency dropped to zero and 404 errors turned into motivational quotes.
+
+“Your content is just loading its potential!” they would say, bringing tears to the eyes of developers and hummingbirds alike.
+
+The townsfolk of Serverlandia adored nginx. They built shrines out of old USB cables and offered it snacks made of finely spun JSON. Even the databases—who were notoriously grumpy—would sing praises of nginx’s load balancing lullabies. Apache, the wise old monk of the hills, once tried to challenge nginx to a duel of requests-per-second, but halfway through the contest he just sighed, gave nginx a hug, and invited it to tea.
+
+At night, nginx would tuck in the children of the village by wrapping their bedtime stories in TLS encryption and caching their dreams for extra speed. Unicorns danced across CDN rainbows, singing songs about scalability and uptime. The moon itself would giggle as nginx gracefully handled a billion concurrent connections while baking cookies shaped like serverless functions.
+
+Even the grumpy firewall trolls came around, offering friendly port forwards and warm handshakes. Life was good. Load times were fast. The air smelled faintly of peppermint and perfectly formed XML.
+
+And thus, in a land where packets flowed like chocolate rivers and downtime was just a scary campfire story, nginx reigned supreme—not with power, but with kindness, balance, and beautifully efficient asynchronous processing.
+
+Everyone lived happily ever after, behind seven layers of security and a content delivery network that sparkled in the sky.
+
+## Testing some headings for the toc 4
+
+Once upon a time in the Technicolor Cloud Kingdom of Serverlandia, a joyful wind blew across the binary meadows, whispering tales of a mystical creature named nginx (pronounced "engine-x" by the locals and "wizard-swoosh" by the jellyfish). It wasn’t a dragon, a unicorn, or a sentient avocado—it was something far more magical: a hyper-fast, ever-smiling web server with the personality of a golden retriever and the efficiency of 10,000 caffeinated squirrels.
+
+Every morning, nginx would wake up with a cheerful beep-boop, stretch its configuration files, and greet the sun with a reverse proxy pirouette. Birds chirped in HTTP headers, and butterflies fluttered by on compressed gzip wings. Wherever nginx went, latency dropped to zero and 404 errors turned into motivational quotes.
+
+“Your content is just loading its potential!” they would say, bringing tears to the eyes of developers and hummingbirds alike.
+
+The townsfolk of Serverlandia adored nginx. They built shrines out of old USB cables and offered it snacks made of finely spun JSON. Even the databases—who were notoriously grumpy—would sing praises of nginx’s load balancing lullabies. Apache, the wise old monk of the hills, once tried to challenge nginx to a duel of requests-per-second, but halfway through the contest he just sighed, gave nginx a hug, and invited it to tea.
+
+At night, nginx would tuck in the children of the village by wrapping their bedtime stories in TLS encryption and caching their dreams for extra speed. Unicorns danced across CDN rainbows, singing songs about scalability and uptime. The moon itself would giggle as nginx gracefully handled a billion concurrent connections while baking cookies shaped like serverless functions.
+
+Even the grumpy firewall trolls came around, offering friendly port forwards and warm handshakes. Life was good. Load times were fast. The air smelled faintly of peppermint and perfectly formed XML.
+
+And thus, in a land where packets flowed like chocolate rivers and downtime was just a scary campfire story, nginx reigned supreme—not with power, but with kindness, balance, and beautifully efficient asynchronous processing.
+
+Everyone lived happily ever after, behind seven layers of security and a content delivery network that sparkled in the sky.
+
+## Testing some headings for the toc 5
+
+Once upon a time in the Technicolor Cloud Kingdom of Serverlandia, a joyful wind blew across the binary meadows, whispering tales of a mystical creature named nginx (pronounced "engine-x" by the locals and "wizard-swoosh" by the jellyfish). It wasn’t a dragon, a unicorn, or a sentient avocado—it was something far more magical: a hyper-fast, ever-smiling web server with the personality of a golden retriever and the efficiency of 10,000 caffeinated squirrels.
+
+Every morning, nginx would wake up with a cheerful beep-boop, stretch its configuration files, and greet the sun with a reverse proxy pirouette. Birds chirped in HTTP headers, and butterflies fluttered by on compressed gzip wings. Wherever nginx went, latency dropped to zero and 404 errors turned into motivational quotes.
+
+“Your content is just loading its potential!” they would say, bringing tears to the eyes of developers and hummingbirds alike.
+
+The townsfolk of Serverlandia adored nginx. They built shrines out of old USB cables and offered it snacks made of finely spun JSON. Even the databases—who were notoriously grumpy—would sing praises of nginx’s load balancing lullabies. Apache, the wise old monk of the hills, once tried to challenge nginx to a duel of requests-per-second, but halfway through the contest he just sighed, gave nginx a hug, and invited it to tea.
+
+At night, nginx would tuck in the children of the village by wrapping their bedtime stories in TLS encryption and caching their dreams for extra speed. Unicorns danced across CDN rainbows, singing songs about scalability and uptime. The moon itself would giggle as nginx gracefully handled a billion concurrent connections while baking cookies shaped like serverless functions.
+
+Even the grumpy firewall trolls came around, offering friendly port forwards and warm handshakes. Life was good. Load times were fast. The air smelled faintly of peppermint and perfectly formed XML.
+
+And thus, in a land where packets flowed like chocolate rivers and downtime was just a scary campfire story, nginx reigned supreme—not with power, but with kindness, balance, and beautifully efficient asynchronous processing.
+
+Everyone lived happily ever after, behind seven layers of security and a content delivery network that sparkled in the sky.

--- a/exampleSite/content/test-product/sidebar/nesting-1c/nesting-2/nesting-3/_index.md
+++ b/exampleSite/content/test-product/sidebar/nesting-1c/nesting-2/nesting-3/_index.md
@@ -1,0 +1,4 @@
+---
+description: Nesting-3
+title: Nesting-3
+---

--- a/layouts/_default/docs.html
+++ b/layouts/_default/docs.html
@@ -74,7 +74,7 @@
       </nav>
     </div>
 
-    <section class="content-layout">
+    <section id="maincontent" class="content-layout">
       <div data-cms-edit="content" class="text-content">
         <section class="breadcrumb-layout" data-mf="true" style="display: none;">
           {{ if not .IsHome }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -18,7 +18,7 @@
     </nav>
   </div>
 
-  <section class="content-layout" data-mf="true" style="display: none">
+  <section id="maincontent" class="content-layout" data-mf="true" style="display: none">
     <div data-cms-edit="content" class="text-content list-page">
       <section class="breadcrumb-layout">
         {{ if not .IsHome }}

--- a/layouts/partials/lucide.html
+++ b/layouts/partials/lucide.html
@@ -1,5 +1,6 @@
 {{- /* Usage: */ -}}
 {{- /* (dict "context" . "icon" "circle") */ -}}
-<svg class="lucide" style="{{ .style | safeCSS }}" data-mf="true" style="display: none">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" aria-hidden="true" class="lucide"
+    style="{{ .style | safeCSS }}" data-mf="true" style="display: none">
     <use href="/images/lucide-sprite.svg#{{ .icon }}"></use>
 </svg>

--- a/layouts/partials/sidebar-list.html
+++ b/layouts/partials/sidebar-list.html
@@ -17,10 +17,10 @@
           aria-expanded="{{ $shouldExpand }}"
           aria-controls="{{ $sectionID }}"
         >
+          <span class="sidebar__toggle-text">{{ .Title }}</span>
           <span class="sidebar__chevron {{ if $shouldExpand }}sidebar__chevron--open{{ end }}">
             {{ partial "lucide" (dict "context" . "icon" "chevron-right") }}
           </span>
-          <span class="sidebar__toggle-text">{{ .Title }}</span>
         </button>
         <div
           id="{{ $sectionID }}"

--- a/layouts/partials/sidebar-list.html
+++ b/layouts/partials/sidebar-list.html
@@ -1,0 +1,61 @@
+{{ $currentUrl := .currentUrl }}
+{{ $firstSection := .firstSection }}
+{{ $currentPage := .currentPage }}
+
+{{ with $firstSection }}
+<ul class="sidebar__ul">
+  {{ range .Pages.ByWeight }}
+    {{- $onPage := eq $currentUrl .Permalink -}}
+    {{- $isAncestor := .IsAncestor $currentPage -}}
+    {{- $shouldExpand := or $onPage $isAncestor -}}
+    {{- $sectionID := printf "section-%s" (urlize .Permalink) -}}
+
+    {{ if eq .Kind "section" }}
+      <li class="sidebar__section">
+        <button
+          class="sidebar__toggle"
+          aria-expanded="{{ $shouldExpand }}"
+          aria-controls="{{ $sectionID }}"
+        >
+          {{ .Title }}
+        </button>
+
+        <div
+          id="{{ $sectionID }}"
+          class="sidebar__children"
+          {{ if not $shouldExpand }}hidden{{ end }}
+        >
+          {{ partial "sidebar-list.html" (dict
+            "firstSection" . "currentUrl" $currentUrl "currentPage" $currentPage)
+          }}
+        </div>
+      </li>
+
+    {{ else if eq .Kind "page" }}
+      <li class="sidebar__page">
+        <a
+          href="{{ .Permalink }}"
+          class="sidebar__link {{ if $onPage }}sidebar__link--current{{ end }}"
+          {{ if $onPage }}aria-current="page"{{ end }}
+        >
+          {{ .Title }}
+        </a>
+        {{ if $onPage }}
+          {{ with .TableOfContents }}
+            <div class="sidebar__toc" id="TableOfContents">{{ . }}</div>
+          {{ end }}
+        {{ end }}
+      </li>
+    {{ end }}
+  {{ end }}
+</ul>
+{{ end }}
+
+
+{{/*  {{ if gt (.WordCount) 0 }}
+<ul>
+  <li>
+    <a href="{{ .Permalink }}" style="color: purple; {{if $onPage}}font-weight: bold;{{end}}">{{ .Title }} - Overview</a>
+  </li>
+</ul>
+{{ end }}  */}}

--- a/layouts/partials/sidebar-list.html
+++ b/layouts/partials/sidebar-list.html
@@ -1,23 +1,31 @@
 {{ $currentUrl := .currentUrl }}
-{{ $firstSection := .firstSection }}
 {{ $currentPage := .currentPage }}
+{{ $firstSection := .firstSection }}
+{{ $idPrefix := .idPrefix }}
 
 {{ with $firstSection }}
 <ul class="sidebar__ul">
-  {{ range .Pages.ByWeight }}
-    {{- $onPage := eq $currentUrl .Permalink -}}
-    {{- $isAncestor := .IsAncestor $currentPage -}}
+  {{ $pages := .Pages.ByWeight }}
+  {{ range $index, $p := $pages }}
+    {{- $onPage := eq $currentUrl $p.Permalink -}}
+    {{- $isAncestor := $p.IsAncestor $currentPage -}}
     {{- $shouldExpand := or $onPage $isAncestor -}}
-    {{- $sectionID := printf "section-%s" (urlize .Permalink) -}}
+    {{/*  These variables are used to create a unique id to be attached to every link
+    that accessibility users can correctly "Skip Table Of Contents"  */}}
+    {{- $sectionID := printf "%ssection-%s" $idPrefix (urlize $p.Permalink) -}}
+    {{- $linkID := printf "%slink-%s" $idPrefix (urlize $p.Permalink) -}}
+    {{- $nextIndex := add $index 1 -}}
+    {{- $nextLink := index $pages $nextIndex -}}
 
-    {{ if eq .Kind "section" }}
+    {{ if eq $p.Kind "section" }}
       <li class="sidebar__section">
         <button
+          id="{{ $linkID }}"
           class="sidebar__toggle {{ if $isAncestor }}sidebar__toggle--ancestor{{ end }}"
           aria-expanded="{{ $shouldExpand }}"
           aria-controls="{{ $sectionID }}"
         >
-          <span class="sidebar__toggle-text">{{ .Title }}</span>
+          <span class="sidebar__toggle-text">{{ $p.Title }}</span>
           <span class="sidebar__chevron {{ if $shouldExpand }}sidebar__chevron--open{{ end }}">
             {{ partial "lucide" (dict "context" . "icon" "chevron-right") }}
           </span>
@@ -28,44 +36,56 @@
           {{ if not $shouldExpand }}hidden{{ end }}
         >
           {{ partial "sidebar-list.html" (dict
-            "firstSection" . "currentUrl" $currentUrl "currentPage" $currentPage)
-          }}
+            "firstSection" $p
+            "currentUrl" $currentUrl
+            "currentPage" $currentPage
+            "idPrefix" (printf "%s%s-" $idPrefix (urlize $p.Title))
+          ) }}
         </div>
       </li>
 
-      {{ else if eq .Kind "page" }}
+    {{ else if eq $p.Kind "page" }}
+      {{- $tocHasItems := (in $p.TableOfContents "<li>") -}}
+      {{- $pageHasTOC := (and $onPage $tocHasItems $p.Params.toc) -}}
+      {{- $tocID := printf "%stoc-%s" $idPrefix (urlize $p.Permalink) -}}
       <li class="sidebar__page">
-        {{- $pageHasTOC := (and $onPage .TableOfContents) -}}
-        {{- $tocID := printf "toc-%s" (urlize .Permalink) -}}
-        {{- if $pageHasTOC }}
+        {{ if $pageHasTOC }}
           <button
             class="sidebar__toggle sidebar__link sidebar__link--current"
             aria-expanded="true"
             aria-controls="{{ $tocID }}"
+            id="{{ $linkID }}"
           >
-            <span>{{ .Title }}</span>
+            <span>{{ $p.Title }}</span>
             <span class="sidebar__chevron sidebar__chevron--open">
               {{ partial "lucide" (dict "context" . "icon" "chevron-right") }}
             </span>
           </button>
           <div id="{{ $tocID }}" class="sidebar__toc">
-            {{ .TableOfContents }}
+            {{ if $nextLink }}
+              {{- $nextLinkID := printf "%slink-%s" $idPrefix (urlize $nextLink.Permalink) -}}
+              <a class="skip-link" href="#{{ $nextLinkID }}">Skip Table of Contents</a>
+            {{ else }}
+              <a class="skip-link" href="#maincontent">Skip Table of Contents</a>
+            {{ end }}
+              {{ $p.TableOfContents }}
           </div>
         {{ else }}
           <a
-            href="{{ .Permalink }}"
+            href="{{ $p.Permalink }}"
+            id="{{ $linkID }}"
             class="sidebar__link {{ if $onPage }}sidebar__link--current{{ end }}"
             {{ if $onPage }}aria-current="page"{{ end }}
           >
-            {{ .Title }}
+            {{ $p.Title }}
           </a>
         {{ end }}
       </li>
     {{ end }}
+
   {{ end }}
 </ul>
 {{ end }}
-
 
 {{/*  {{ if gt (.WordCount) 0 }}
 <ul>

--- a/layouts/partials/sidebar-list.html
+++ b/layouts/partials/sidebar-list.html
@@ -9,27 +9,30 @@
     {{- $isAncestor := .IsAncestor $currentPage -}}
     {{- $shouldExpand := or $onPage $isAncestor -}}
     {{- $sectionID := printf "section-%s" (urlize .Permalink) -}}
+
     {{ if eq .Kind "section" }}
-    <li class="sidebar__section">
-      <button
-        class="sidebar__toggle"
-        aria-expanded="{{ $shouldExpand }}"
-        aria-controls="{{ $sectionID }}"
-      >
-        <span class="sidebar__chevron {{ if $shouldExpand }}sidebar__chevron--open{{ end }}">
-          {{ partial "lucide" (dict "context" . "icon" "chevron-right") }}
-        </span>
-        <span class="sidebar__toggle-text">{{ .Title }}</span>
-      </button>
-      <div
-        id="{{ $sectionID }}"
-        class="sidebar__children"
-        {{ if not $shouldExpand }}hidden{{ end }}
-      >
-        {{ partial "sidebar-list.html" (dict 
-          "firstSection" . "currentUrl" $currentUrl "currentPage" $currentPage) }}
-      </div>
-    </li>
+      <li class="sidebar__section">
+        <button
+          class="sidebar__toggle {{ if $isAncestor }}sidebar__toggle--ancestor{{ end }}"
+          aria-expanded="{{ $shouldExpand }}"
+          aria-controls="{{ $sectionID }}"
+        >
+          <span class="sidebar__chevron {{ if $shouldExpand }}sidebar__chevron--open{{ end }}">
+            {{ partial "lucide" (dict "context" . "icon" "chevron-right") }}
+          </span>
+          <span class="sidebar__toggle-text">{{ .Title }}</span>
+        </button>
+        <div
+          id="{{ $sectionID }}"
+          class="sidebar__children"
+          {{ if not $shouldExpand }}hidden{{ end }}
+        >
+          {{ partial "sidebar-list.html" (dict
+            "firstSection" . "currentUrl" $currentUrl "currentPage" $currentPage)
+          }}
+        </div>
+      </li>
+
     {{ else if eq .Kind "page" }}
       <li class="sidebar__page">
         <a
@@ -39,13 +42,13 @@
         >
           {{ .Title }}
         </a>
+
         {{ if $onPage }}
           {{ with .TableOfContents }}
             <div class="sidebar__toc" id="TableOfContents">{{ . }}</div>
           {{ end }}
         {{ end }}
       </li>
-      
     {{ end }}
   {{ end }}
 </ul>

--- a/layouts/partials/sidebar-list.html
+++ b/layouts/partials/sidebar-list.html
@@ -33,20 +33,32 @@
         </div>
       </li>
 
-    {{ else if eq .Kind "page" }}
+      {{ else if eq .Kind "page" }}
       <li class="sidebar__page">
-        <a
-          href="{{ .Permalink }}"
-          class="sidebar__link {{ if $onPage }}sidebar__link--current{{ end }}"
-          {{ if $onPage }}aria-current="page"{{ end }}
-        >
-          {{ .Title }}
-        </a>
-
-        {{ if $onPage }}
-          {{ with .TableOfContents }}
-            <div class="sidebar__toc" id="TableOfContents">{{ . }}</div>
-          {{ end }}
+        {{- $pageHasTOC := (and $onPage .TableOfContents) -}}
+        {{- $tocID := printf "toc-%s" (urlize .Permalink) -}}
+        {{- if $pageHasTOC }}
+          <button
+            class="sidebar__toggle sidebar__link sidebar__link--current"
+            aria-expanded="true"
+            aria-controls="{{ $tocID }}"
+          >
+            <span>{{ .Title }}</span>
+            <span class="sidebar__chevron sidebar__chevron--open">
+              {{ partial "lucide" (dict "context" . "icon" "chevron-right") }}
+            </span>
+          </button>
+          <div id="{{ $tocID }}" class="sidebar__toc">
+            {{ .TableOfContents }}
+          </div>
+        {{ else }}
+          <a
+            href="{{ .Permalink }}"
+            class="sidebar__link {{ if $onPage }}sidebar__link--current{{ end }}"
+            {{ if $onPage }}aria-current="page"{{ end }}
+          >
+            {{ .Title }}
+          </a>
         {{ end }}
       </li>
     {{ end }}

--- a/layouts/partials/sidebar-list.html
+++ b/layouts/partials/sidebar-list.html
@@ -9,28 +9,27 @@
     {{- $isAncestor := .IsAncestor $currentPage -}}
     {{- $shouldExpand := or $onPage $isAncestor -}}
     {{- $sectionID := printf "section-%s" (urlize .Permalink) -}}
-
     {{ if eq .Kind "section" }}
-      <li class="sidebar__section">
-        <button
-          class="sidebar__toggle"
-          aria-expanded="{{ $shouldExpand }}"
-          aria-controls="{{ $sectionID }}"
-        >
-          {{ .Title }}
-        </button>
-
-        <div
-          id="{{ $sectionID }}"
-          class="sidebar__children"
-          {{ if not $shouldExpand }}hidden{{ end }}
-        >
-          {{ partial "sidebar-list.html" (dict
-            "firstSection" . "currentUrl" $currentUrl "currentPage" $currentPage)
-          }}
-        </div>
-      </li>
-
+    <li class="sidebar__section">
+      <button
+        class="sidebar__toggle"
+        aria-expanded="{{ $shouldExpand }}"
+        aria-controls="{{ $sectionID }}"
+      >
+        <span class="sidebar__chevron {{ if $shouldExpand }}sidebar__chevron--open{{ end }}">
+          {{ partial "lucide" (dict "context" . "icon" "chevron-right") }}
+        </span>
+        <span class="sidebar__toggle-text">{{ .Title }}</span>
+      </button>
+      <div
+        id="{{ $sectionID }}"
+        class="sidebar__children"
+        {{ if not $shouldExpand }}hidden{{ end }}
+      >
+        {{ partial "sidebar-list.html" (dict 
+          "firstSection" . "currentUrl" $currentUrl "currentPage" $currentPage) }}
+      </div>
+    </li>
     {{ else if eq .Kind "page" }}
       <li class="sidebar__page">
         <a
@@ -46,6 +45,7 @@
           {{ end }}
         {{ end }}
       </li>
+      
     {{ end }}
   {{ end }}
 </ul>

--- a/layouts/partials/sidebar-v2.html
+++ b/layouts/partials/sidebar-v2.html
@@ -23,10 +23,12 @@
 
 <div class="sidebar__container">
     <div class="sidebar__content">
+        <a class="skip-link" href="#maincontent">Skip Navigation</a>
         {{ partial "sidebar-list.html" (dict
         "firstSection" .FirstSection
         "currentUrl" .Permalink
         "currentPage" .
+        "idPrefix" ""
       ) }}
     </div>
 </div>

--- a/layouts/partials/sidebar-v2.html
+++ b/layouts/partials/sidebar-v2.html
@@ -21,72 +21,12 @@
 {{ $productIdentifier := index ((split $relPermalink "/")) 1 }}
 {{ $productName := index $productMap $productIdentifier }}
 
-<atomic-search-interface id="search-standalone-sidebar" data-mf="true" style="display:none;">
-    <atomic-search-box redirection-url="/search.html">
-    </atomic-search-box>
-</atomic-search-interface>
-<button class="product-selector-button" id="product-selector-button">
-    {{/* product name and selector */}}
-    <div class="product-selector-name" id="product-selector-name">{{ $productName }}</div>
-    <div class="product-selector-button-icon" id="product-selector-button-icon">
-        <svg width="8" height="14" viewBox="0 0 8 14" fill="none" xmlns="http://www.w3.org/2000/svg" id="product-selector-chevron-icon">
-            <path d="M1 13L7 7L0.999999 1" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" id="product-selector-chevron-icon"/>
-        </svg>     
-    </div>
-</button>
-<div class="product-selector" id="product-selector">
-    {{ $groupedProducts := dict 
-        "nginx-one" (where $nginxProducts "type" "nginx-one")
-        "nginx-app-protect" (where $nginxProducts "type" "nginx-app-protect")
-        "nginx-as-a-service" (where $nginxProducts "type" "nginx-as-a-service")
-        "nginx-other" (where $nginxProducts "type" "nginx-other")
-    }}
-    {{ $orderedKeys := slice "nginx-one" "nginx-app-protect" "nginx-as-a-service" "nginx-other" }}
-    {{ range $orderedKeys }}
-    {{ $type := . }}
-    {{ $products := index $groupedProducts $type }}
-        <div class="product-selector-content" id="product-selector-content">
-            <p id="product-selector-content-product-group-name">{{ $type | humanize | title | upper }}</p>
-            <ul id="product-selector-content-product-container">
-            {{ range $products }}
-                <li id="product-selector-content-product-name">
-                    <a id="product-selector-content-product-link" href="{{ .url }}">{{ .title }}</a>
-                </li>
-            {{ end }}
-            </ul>
-        </div>
-    {{ end }}
-</div>
-<div class="scrollbar-container">
-    <div class="sidebar-navigation">
-        <ul class="parent-collapsible-content">
-        {{ range .FirstSection.Pages.ByWeight }}
-            <li class="parent-collapsible-content-item">
-                {{ if eq .Kind "section" }}
-                    <input type="checkbox" id="toggle-{{ .File.UniqueID }}" class="toggle-checkbox" style="display: none;">
-                    <label for="toggle-{{ .File.UniqueID }}" class="collapsible-header">
-                        {{ if .Pages }}
-                            <span class="parent-box expand"></span>
-                            <span class="parent-box opened"></span>
-                        {{ end }}
-                        {{ .Title }} 
-                    </label>
-                    {{ partial "sidebar-list-pages.html" (dict "context" . "currentUrl" $.Permalink) }}
-                {{ else if eq .Kind "page" }}
-                    {{ if eq $.Permalink .Permalink }}                      
-                        <span class="parent-box current"></span>                 
-                    {{ else }}                     
-                        <span class="parent-box-link"></span>              
-                    {{ end }}
-                    <a href="{{ .Permalink }}" style="{{if eq $.Permalink .Permalink}}font-weight: bold;{{end}}">{{ .Title }} </a> 
-                    {{ if eq  $.Permalink .Permalink }} 
-                        {{- with .TableOfContents -}}
-                            {{- . -}}
-                        {{- end -}}
-                    {{ end }}
-                {{ end }}
-            </li>
-        {{ end }}
-        </ul>
+<div class="sidebar__container">
+    <div class="sidebar__content">
+        {{ partial "sidebar-list.html" (dict
+        "firstSection" .FirstSection
+        "currentUrl" .Permalink
+        "currentPage" .
+      ) }}
     </div>
 </div>

--- a/layouts/search/single.html
+++ b/layouts/search/single.html
@@ -121,7 +121,6 @@
 
       <!-- Facet Section -->
       <atomic-layout-section section="facets">
-        <atomic-search-box id="search-standalone-searchpage"></atomic-search-box>
         <atomic-facet field="f5_product" label="Show by product"></atomic-facet>
         <atomic-refine-toggle></atomic-refine-toggle>
       </atomic-layout-section>


### PR DESCRIPTION
This is a from scratch sidebar implementation iterating on @danielledeleo branch and design feedback.

It should work like a sidebar, as expected 🤞 . 
Takes the `toc` frontmatter into account, to render or not render the table of contents.

Product selector and search are removed from the sidebar. The search now lives in the header, and the product selector will likely end up there as well, but it's not part of this PR.

The table of contents is within the sidebar still, and can be hidden/shown.
There are two a11y hidden links for skipping the sidebar entirely, or just skipping the table of contents you're on.
There's also a fix in here for icons, so that they resize properly via css.

I'd like to get this merged with it's current feature set, but there are some `TODOs` for future PRs:
- Add an `overview` page nodes that have content in their `_index.md` file. This is important, since you can no longer click directly on a node with pages to see a "list" view.
- Try to make the green hover/selected background spread across the full width of the sidebar. Fought with CSS for a while, but had to call it!

###  a11y skipper for table of contents
For users
<img width="384" alt="Screenshot 2025-05-07 at 16 07 47" src="https://github.com/user-attachments/assets/83329d0a-d301-4520-a346-54343f29f16c" />

### a11y skipper for entire sidebar
<img width="395" alt="Screenshot 2025-05-07 at 16 07 31" src="https://github.com/user-attachments/assets/a2a35ff1-ce32-4da6-b700-b5629c2cd112" />

### Screenshots of various states below
<img width="373" alt="Screenshot 2025-05-07 at 16 07 25" src="https://github.com/user-attachments/assets/7738e572-1a24-43e6-bbf4-d819a6634659" />


<img width="382" alt="Screenshot 2025-05-07 at 16 07 03" src="https://github.com/user-attachments/assets/f5c46b5e-006b-48e4-8dfb-3a348c7ec9aa" />


<img width="377" alt="Screenshot 2025-05-07 at 16 06 54" src="https://github.com/user-attachments/assets/288503c8-f34c-404f-881d-3725c9f05200" />


<img width="1097" alt="Screenshot 2025-05-07 at 16 06 46" src="https://github.com/user-attachments/assets/7139a147-eece-46bf-82c3-887c3bdb03b9" />
