### PR TITLE
Sidebar: Fix empty whitespace

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -912,6 +912,12 @@ button:has(~ .product-selector[style*="none"]) > .product-selector-button-icon {
         padding: 0.25rem 0.75rem;
       }
 
+      /* handles bug in hugo where non-rendered headers cause empty li */
+      /* https://github.com/gohugoio/hugo/issues/7128 */
+      li:empty {
+        display: none;
+      }
+
       li:first-child {
         padding-top: 0;
       }


### PR DESCRIPTION
Fixes whitespace in table of contents caused by `hX` elements we don't render (> 3).
This is a known issue in hugo - https://github.com/gohugoio/hugo/issues/7128

<img width="367" alt="Screenshot 2025-05-14 at 11 29 38" src="https://github.com/user-attachments/assets/968ee7ab-2e82-4567-aaf3-8891b52cd9f5" />
<img width="343" alt="Screenshot 2025-05-14 at 10 37 52" src="https://github.com/user-attachments/assets/4bc022d7-b47d-4a52-a0dd-18ea24251727" />
