### PR TITLE
Precommit: Add gitleaks scanning to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,8 +6,14 @@ repos:
         entry: scripts/lint-commit.sh
         stages: [ commit-msg ]
         language: system
+
       - id: run-biome
         name: Check for linting and formatting for source code using Biome
         entry: scripts/run-biome.sh
         stages: [ pre-commit ]
         language: system
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.26.0
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
Add [gitleaks](https://github.com/gitleaks/gitleaks) to our precommit checks.
This should only check for changes related to your commit, so it should run _very fast_ unless your commit is huge.

<img width="886" alt="image" src="https://github.com/user-attachments/assets/87b35eca-6d12-4bf2-88a1-f99bd1f74d5a" />
