### PR TITLE
Callout: Remove whitespace when icon not included

### DIFF
--- a/exampleSite/content/test-product/tab-group/tab-group.md
+++ b/exampleSite/content/test-product/tab-group/tab-group.md
@@ -8,6 +8,22 @@ weight: 200
 
 {{<tabs name="common_steps_for_nginx_oss_and_plus">}}
 
+{{%tab name="Call Outs"%}}
+
+{{<call-out "caution call-out" "Deprecated documentation notice" "fa fa-exclamation-triangle" >}}
+This is a callout with an icon.
+{{</call-out>}}
+
+{{<caution>}}
+This is a Caution callout. There was previously a bug with **bold text** that we should be aware of and continue to check for. This callout was invoked with the `<caution>` shortcode. It has no custom title.
+{{</caution>}}
+
+{{<call-out "" "Custom title">}}
+This is a plain callout with a title. It has a [link](#plain-callouts) to a heading on this page. Its shortcode is `<call-out>` with a custom title parameter.
+{{</call-out>}}
+
+{{%/tab%}}
+
 {{%tab name="Ordered List With Code Block types"%}}
 
 1. Create the `/etc/ssl/nginx` directory:
@@ -40,6 +56,8 @@ nginx -s reload
 ```
 
 {{%/tab%}}
+
+
 {{</tabs>}}
 
 

--- a/layouts/partials/callout.html
+++ b/layouts/partials/callout.html
@@ -24,9 +24,9 @@
 {{/*  Old frame callout  */}}
 <blockquote class="{{ $class }}" data-mf="false">
   <div>
-    {{ with $icon }}
+    {{- with $icon -}}
       <i class="{{ . }}"></i>
-    {{ end }}
+    {{- end -}}
     <strong>{{ $title }}</strong>
     {{ .content | markdownify }}
   </div>
@@ -59,7 +59,7 @@
     </div>
   </blockquote>
 </div>
-  
+
 {{ else }}
 
 {{/*  "Generic" mf callout  */}}
@@ -68,9 +68,9 @@
 
 <blockquote class="{{ $class }} note" data-mf="true" style="display: none;" data-title="{{ $cleanTitle }}">
   <div class="callout-content">
-    {{ with $icon }}
+    {{- with $icon -}}
       <i class="{{ . }}"></i>
-    {{ end }}
+    {{- end -}}
     <div class="callout-content">
     {{ .content | markdownify }}
     </div>


### PR DESCRIPTION
Remove whitespace when `icon` is not rendered in a callout.
_Only_ impacted callouts when nested in a tab group. 
See before and after for oldframe and new frame.

<img width="1179" alt="Screenshot 2025-05-16 at 10 55 43" src="https://github.com/user-attachments/assets/cb52b2d7-788e-462d-a9a9-218daa594bfd" />
<img width="1030" alt="Screenshot 2025-05-16 at 10 54 35" src="https://github.com/user-attachments/assets/de216942-02a4-4bbd-8fbe-34b5e92da953" />
<img width="1186" alt="Screenshot 2025-05-16 at 10 55 36" src="https://github.com/user-attachments/assets/04076891-2b02-4e1e-b684-606a5c23df7e" />
<img width="827" alt="Screenshot 2025-05-16 at 10 54 44" src="https://github.com/user-attachments/assets/e5b81b3c-339c-4a95-8059-52b8b81ce138" />

