### PR TITLE
Fix: Expandos no longer show pointer cursor on whole element

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -1043,9 +1043,6 @@ details summary {
 
 details summary:hover {
   text-decoration-color: oklch(var(--color-brand) / 0.8);
-}
-
-details:hover {
   cursor: pointer;
 }
 

--- a/exampleSite/content/test-product/everything.md
+++ b/exampleSite/content/test-product/everything.md
@@ -66,9 +66,30 @@ This won't render anything.
 
 
 ## details
+<details>
+    <summary>Learn how to pin NGINX Plus to a specific version, closed by default</summary>
+
+And this is the content on how to do so.
+</details>
+
 <details open>
-    <summary>Learn how to pin NGINX Plus to a specific version</summary>
-    And this is the content on how to do so.
+    <summary>example dynamic-agent.conf</summary>
+
+{{<note>}}
+Default location in Linux environments: `/var/lib/nginx-agent/agent-dynamic.conf`
+
+Default location in FreeBSD environments: `/var/db/nginx-agent/agent-dynamic.conf`
+{{</note>}}
+
+```yaml
+# Dynamic configuration file for NGINX Agent.
+
+instance_group: my-instance-group
+tags:
+  - dev
+  - qa
+```
+
 </details>
 
 ## [Heading with link](https://nginx.org/)


### PR DESCRIPTION
### Proposed changes
Expandos were showing the pointer cursor on all elements in the expanded section, not just the expando link.

Also of note is the change to the first example that forces a `<p>` tag to be generated, improving whitespace.

This video shows the before and after:

https://github.com/user-attachments/assets/6a5c3041-ec4d-48a8-9295-b4c1bc258ba9



### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
