### PR TITLE
Shortcode: Add nobreak shortcode and usage exampl

### DIFF
--- a/exampleSite/content/test-product/prose/_index.md
+++ b/exampleSite/content/test-product/prose/_index.md
@@ -1,0 +1,5 @@
+---
+description: Prose
+title: Prose
+weight: 100
+---

--- a/exampleSite/content/test-product/prose/nobreak.md
+++ b/exampleSite/content/test-product/prose/nobreak.md
@@ -1,0 +1,15 @@
+---
+description: Nobreak
+title: Nobreak
+weight: 100
+---
+
+## No break shortcode `nb`
+
+Using the `nb` shorcode should stop words breaking across lines. A common use case would be on things like product names, such as {{<nb>}}NGINX Plus (nobreak) {{</nb>}} vs NGINX Plus (with break).
+
+Usage
+
+``` markdown
+{{</*nb*/>}}NGINX Plus{{</*/nb*/>}}
+```

--- a/layouts/shortcodes/nb.html
+++ b/layouts/shortcodes/nb.html
@@ -1,0 +1,1 @@
+<span style="white-space: nowrap;">{{ .Inner | markdownify }}</span>


### PR DESCRIPTION
Shortcode: Add nobreak shortcode and usage example.

Example below uses `NGINX Plus (nobreak)` as an example.

<img width="732" alt="Screenshot 2025-05-28 at 12 53 37" src="https://github.com/user-attachments/assets/ce11e4dd-c14f-4bd1-b2a1-e68f46a984a3" />
<img width="612" alt="Screenshot 2025-05-28 at 12 53 27" src="https://github.com/user-attachments/assets/28f7e9d9-3813-4e09-9678-0515e842b33f" />
<img width="619" alt="Screenshot 2025-05-28 at 12 53 23" src="https://github.com/user-attachments/assets/6cc0771a-1f76-41df-a5cc-6db4958fa2ed" />

