### PR TITLE
Redocly: Fix oldframe redocly width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ resources/*
 .hugo_build.lock
 public/*
 exampleSite/public
+exampleSite/hugo
 
 # Python
 .venv

--- a/assets/css/f5-hugo.css
+++ b/assets/css/f5-hugo.css
@@ -793,6 +793,10 @@ redoc {
   overscroll-behavior-y: none;
 }
 
+.nginx-docs-api-container {
+    width: 100%;
+}
+
 .nginx-docs-api-container button {
   border-color: inherit;
   box-shadow: none !important;


### PR DESCRIPTION
Fix issue where oldframe was rendering redocly at a fixed small width.

<img width="1544" alt="Screenshot 2025-05-29 at 14 30 25" src="https://github.com/user-attachments/assets/35171159-3715-47d5-bf30-51cfd8cadce1" />


<img width="1484" alt="Screenshot 2025-05-29 at 14 30 33" src="https://github.com/user-attachments/assets/de6db72f-9497-47d2-8bfa-c194001549ef" />
