### PR TITLE
Refactor to add the coveo filter to mobile

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -728,11 +728,6 @@ atomic-search-interface {
   margin-top: 2rem;
 }
 
-#search-standalone-sidebar {
-  min-height: 54px;
-  max-height: 54px;
-}
-
 atomic-search-box {
   &::part(wrapper) {
     border-radius: 0;
@@ -751,6 +746,16 @@ atomic-search-box {
   }
 }
 
+atomic-refine-toggle {
+  display: none;
+}
+
+@media (max-width: 1024px) {
+  atomic-refine-toggle {
+    display: block;
+  }
+}
+
 atomic-query-summary {
   /* Show duration */
   &::part(duration) {
@@ -761,6 +766,7 @@ atomic-query-summary {
 atomic-search-layout {
   grid-template-areas:
     "atomic-section-search"
+    "atomic-section-facets"
     "atomic-section-main"
     "." !important;
 

--- a/layouts/partials/coveo-atomic.html
+++ b/layouts/partials/coveo-atomic.html
@@ -3,6 +3,7 @@
       <!-- Search/Metadata Section -->
       <atomic-layout-section section="search">
         <div class="atomic-full-summary-and-sort">
+          <atomic-refine-toggle></atomic-refine-toggle>
           <atomic-query-summary></atomic-query-summary>
           <atomic-sort-dropdown>
             <atomic-sort-expression label="relevance" expression="relevancy"></atomic-sort-expression>
@@ -14,7 +15,6 @@
       <!-- Facet Section -->
       <atomic-layout-section section="facets">
         <atomic-facet field="f5_product" label="Show by product"></atomic-facet>
-        <atomic-refine-toggle></atomic-refine-toggle>
       </atomic-layout-section>
 
       <!-- Main Section -->


### PR DESCRIPTION
### Proposed changes

Moved `atomic-refine-toggle` (aka button to Sort and Filter) to a different place + add media query so it only shows up on mobile.

Reference: https://docs.coveo.com/en/atomic/latest/reference/components/atomic-refine-toggle/

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
