### PR TITLE
docs: Set up updated list-main for N1C

### DIFF
--- a/layouts/partials/list-main.html
+++ b/layouts/partials/list-main.html
@@ -32,18 +32,38 @@
                                 <i class="fas fa-{{if eq .Kind "page"}}file-alt{{else}}book{{end}} fa-lg card-img-top"></i>
                                 <a href="{{ if .Params.url}}{{ .Params.url}}{{else}}{{ .Permalink }}{{end}}">{{ .Title }}</a>
                             </h3>
-                            {{ if and (eq $PageTitle "F5 NGINX One Console") (eq .Title "How-to guides") }}
-                                <ul style="padding-top: 10px;">
-                                    {{ range .Pages }}
-                                        {{ if eq .Kind "section" }}
-                                            {{ range .Pages }}
-                                                <li><a href="{{ .Permalink }}"> {{ .Title }}</a></li>
-                                            {{ end }}
-                                        {{ end }}
-                                    {{ end }}
-                                </ul>
+                            {{ if and (eq $PageTitle "F5 NGINX One Console") (eq .Title "Manage your NGINX fleet")}}
+                                <p style="padding-bottom: 10px;">Simplify, scale, secure, and collaborate with your NGINX fleet </p> 
+                            {{ end }}
+                            {{ if and (eq $PageTitle "F5 NGINX One Console") (eq .Title "Get started")}}
+                                <p style="padding-bottom: 10px;">See benefits from the NGINX One Console </p> 
+                            {{ end }}
+                            {{ if and (eq $PageTitle "F5 NGINX One Console") (eq .Title "Draft new configurations")}}
+                                <p style="padding-bottom: 10px;">Work with Staged Configurations</p> 
+                            {{ end }}
+<!--                            {{ if and (eq $PageTitle "F5 NGINX One Console") (eq .Title "Secure your fleet")}}
+                                <p style="padding-bottom: 10px;">Configure alerts that match your security policies </p> 
+                            {{ end }} -->
+                            {{ if and (eq $PageTitle "F5 NGINX One Console") (eq .Title "Manage your NGINX instances")}}
+                                <p style="padding-bottom: 10px;">Monitor and maintain your deployments </p> 
+                            {{ end }}
+                            {{ if and (eq $PageTitle "F5 NGINX One Console") (eq .Title "Organize users with RBAC")}}
+                                <p style="padding-bottom: 10px;">Assign responsibilities with role-based access control </p> 
+                            {{ end }}
+                            {{ if and (eq $PageTitle "F5 NGINX One Console") (eq .Title "Automate with the NGINX One API")}}
+                                <p style="padding-bottom: 10px;">Manage your NGINX fleet over REST </p> 
+                            {{ end }}
+                            {{ if and (eq $PageTitle "F5 NGINX One Console") (eq .Title "Glossary")}}
+                                <p style="padding-bottom: 10px;">Learn terms unique to NGINX One Console </p> 
+                            {{ end }}
+                            {{ if and (eq $PageTitle "F5 NGINX One Console") (eq .Title "Connect your instances") }}
+                                <p style="padding-bottom: 10px;">Work with data plane keys, containers, and proxy servers </p> 
+                            {{ end }}
+                            {{ if and (eq $PageTitle "F5 NGINX One Console") (eq .Title "Set up metrics") }}
+                                <p style="padding-bottom: 10px;">Review your deployments in a dashboard </p> 
                             {{ end }}
                             {{ if and (eq $PageTitle "F5 NGINX One Console") (eq .Title "API")}}
+                                <p style="padding-bottom: 10px;">These are API docs</p> <!-- Added text here -->
                                 <ul style="padding-top: 10px;">
                                     {{ range .Pages }}
                                         <li><a href="{{ .Permalink }}"> {{ .Title }}</a></li>


### PR DESCRIPTION
### Proposed changes

As part of the release of the updated NGINX One Console front page, I used layouts/partials/list-main.html in the github.com/nginx/documentation repository.

Since that file now belongs in this nginx-hugo-theme repository, I'm setting up this PR here.

Future: as we start supporting NGINX One Console monitoring of other NGINX products, we'll delete those products from the "Other Products" section. 

Closes #271 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
