### PR TITLE
Coveo: Implement param for left-aligned input on search page

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -732,7 +732,7 @@ atomic-search-interface {
   margin-top: 2rem;
 }
 
-atomic-search-box {
+.header-search-box {
   &::part(wrapper) {
     border-radius: 0;
     border-color: oklch(var(--color-foreground));
@@ -770,15 +770,15 @@ atomic-query-summary {
 atomic-search-layout {
   grid-template-areas:
     "atomic-section-search"
+    "atomic-section-status"
     "atomic-section-facets"
-    "atomic-section-main"
-    "." !important;
+    "atomic-section-main";
 
   grid-template-columns: minmax(50%, 100%) !important;
 
   @media (min-width: 1024px) {
     grid-template-areas:
-      ".                     atomic-section-search"
+      "atomic-section-search atomic-section-status"
       "atomic-section-facets atomic-section-main  "
       "atomic-section-facets .                    " !important;
 
@@ -787,10 +787,17 @@ atomic-search-layout {
   }
 }
 
-atomic-search-layout atomic-layout-section[section="search"] {
+atomic-search-layout atomic-layout-section[section="status"] {
   /* Override Coveo's width to be full */
   max-width: 100%;
+  display: block;
+  width: 100%;
+}
+
+atomic-search-layout atomic-layout-section[section="search"] {
+  /* Override Coveo's width to be full */
   width: 100% !important;
+  max-width: 100% !important;
 }
 
 .atomic-full-summary-and-sort {

--- a/exampleSite/content/search.md
+++ b/exampleSite/content/search.md
@@ -1,0 +1,7 @@
+---
+type: search
+title: Search
+params:
+  searchOnPage: true
+url: search.html
+---

--- a/layouts/partials/coveo-atomic-search.html
+++ b/layouts/partials/coveo-atomic-search.html
@@ -1,4 +1,4 @@
 <atomic-search-interface id="search-standalone-header" data-mf="true" style="display:none;">
-    <atomic-search-box redirection-url="/search.html">
+    <atomic-search-box redirection-url="/search.html" class="header-search-box">
     </atomic-search-box>
 </atomic-search-interface>

--- a/layouts/partials/coveo-atomic.html
+++ b/layouts/partials/coveo-atomic.html
@@ -1,7 +1,12 @@
 <atomic-search-interface id="search-v2">
     <atomic-search-layout>
       <!-- Search/Metadata Section -->
-      <atomic-layout-section section="search">
+      {{ if .Params.searchOnPage }}
+        <atomic-layout-section section="search">
+          <atomic-search-box></atomic-search-box>
+        </atomic-layout-section>
+      {{ end }}
+      <atomic-layout-section section="status">
         <div class="atomic-full-summary-and-sort">
           <atomic-refine-toggle></atomic-refine-toggle>
           <atomic-query-summary></atomic-query-summary>


### PR DESCRIPTION
### Proposed changes

This PR allows for theme consumers to add a search input directly to the search page; allowing for usage in cases where there isn't one present in the nav/header.

An example of the param usage was added to the `exampleSite` and resembles the following surface:

**search.md**
```
params:
  searchOnPage: true
```

When not supply the page param, previous page behavior and layout is preserved.

#### searchOnPage Param Toggled (Theme Consumer)

![CleanShot 2025-06-06 at 13 07 06](https://github.com/user-attachments/assets/482eb89a-914a-4ed4-8e0e-748f96dcef62)

#### searchOnPage Param Toggled Off (Example Site)

![CleanShot 2025-06-06 at 13 09 01](https://github.com/user-attachments/assets/b73beca8-1dae-4e64-89c2-d294b0c7fe74)


### Checklist

Before creating a PR, run through this checklist and mark each as complete.
- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
