### PR TITLE
Move changelog-date partial to theme from documentation

### DIFF
--- a/layouts/partials/changelog-date.html
+++ b/layouts/partials/changelog-date.html
@@ -1,0 +1,10 @@
+{{ $changelogContent := readFile "content/nginx-one/changelog.md" }}
+{{ $maxNumLogs := 3 }}
+{{ $headings := first $maxNumLogs (findRE `(?m)^##\s(.+)$` $changelogContent) }}
+<ul>
+  {{ range $headings }}
+  {{ $title := replaceRE "^##\\s" "" . }}
+  <li><a href="{{ absURL "nginx-one/changelog/" }}#{{urlize $title}}">{{ $title }}</a></li>
+  {{ end }}  
+  <li><a href="{{ absURL "nginx-one/changelog/" }}">Older...</a></li>
+</ul>


### PR DESCRIPTION
### Proposed changes

Remove `changelog-date.html` from documentation repo and added to theme for better maintainability. 

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
