### PR TITLE
Fixed how cards are arranged

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -1202,6 +1202,7 @@ h6:has(a):hover {
 /* Landing page cards */
 .text-content .card-layout {
   grid-column: 1;
+  margin-top: 1rem;
 
   .card-section {
     display: flex;
@@ -1248,6 +1249,24 @@ h6:has(a):hover {
   &:not(:has(.featured-card)) *:nth-child(n + 3 of div.card-container) {
     grid-column: 1 / -1;
   }
+
+  &:not(:has(.featured-card))
+    *:nth-child(n + 3 of div.card-container):has(
+      ~ *:nth-child(n + 4 of div.card-container)
+    ) {
+    grid-column: auto;
+  }
+
+  &:not(:has(.featured-card)) *:nth-child(n + 4 of div.card-container) {
+    grid-column: auto;
+  }
+
+  &:not(:has(.featured-card))
+    *:nth-last-child(1 of div.card-container):nth-child(
+      odd of div.card-container
+    ) {
+    grid-column: 1 / -1;
+  }
 }
 
 .card-container {
@@ -1279,6 +1298,7 @@ h6:has(a):hover {
   gap: 1.5rem;
   align-items: center;
   justify-content: start;
+  margin-bottom: 1rem;
 
   img {
     width: auto;


### PR DESCRIPTION
### Proposed changes

Fixed how cards are arranged. Should follow a "2-1" format correctly, where in a full subset of three cards, first two are half sized, and last one is full sized. In practical terms, every card should be half sized except last odd numbered card.

Before (for 5 cards):
![Screenshot 2025-07-03 at 3 19 37 PM](https://github.com/user-attachments/assets/f1bc3179-3430-430a-92b7-8da7b550ef77)

After:
![Screenshot 2025-07-03 at 3 19 26 PM](https://github.com/user-attachments/assets/578457f8-905e-4409-9d41-7b1813e1d808)

Before (for 4 cards):
![Screenshot 2025-07-03 at 3 22 57 PM](https://github.com/user-attachments/assets/20a0d396-ca59-4315-9f4e-22d97532c4eb)

After:
![Screenshot 2025-07-03 at 3 23 06 PM](https://github.com/user-attachments/assets/93a8f545-6897-44e1-b46e-40d958d3beb9)

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
