### PR TITLE
Fixed width for current page section button on Sidebar

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -1292,8 +1292,6 @@ nav.sidebar.sidebar__mobile-open {
     background-color: oklch(var(--color-brand) / 0.1);
     font-weight: 600;
     display: flex;
-    justify-self: stretch;
-    width: auto;
     box-sizing: border-box;
   }
 


### PR DESCRIPTION
### Proposed changes

Closes https://github.com/nginxinc/docs-platform/issues/580

Before (Firefox):
<img width="355" height="45" alt="Screenshot 2025-07-28 at 10 49 53 AM" src="https://github.com/user-attachments/assets/f2f36e17-588e-4fe4-8a82-090bf41d3de4" />

After:
<img width="363" height="56" alt="Screenshot 2025-07-28 at 10 49 34 AM" src="https://github.com/user-attachments/assets/0330ed34-247b-4af8-8f7f-1d10b44cfd58" />

Verified it doesn't break as well in Chrome and Safari


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
