### PR TITLE
TabGroup: Simpler underline style

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -212,7 +212,7 @@ textarea:not([rows]) {
   --details-margin: 0.5rem 0rem;
 
   /* Tab Group */
-  --magrin-tab-group: 1rem 0 0 0;
+  --margin-tab-group: 1rem -1rem 0 -1rem;
 
   --overflow-gutter-extension: 1rem;
 
@@ -1856,9 +1856,10 @@ li:has(> div > blockquote) {
 
 /* MARK: Tabs
 */
+
+/* NOTE: :checked selectors defined in layouts/shortcodes/tabs.html */
 .tabs-container {
   width: calc(100% + 2rem);
-  margin-inline-start: -1rem;
   margin: var(--margin-tab-group);
 
   input[type="radio"] {
@@ -1873,18 +1874,12 @@ li:has(> div > blockquote) {
     scrollbar-width: none;
     white-space: nowrap;
     margin: 0;
-    padding-inline-start: 2rem;
-
-    > :not(:last-child) {
-      border-right: none;
-    }
+    padding-inline-start: 1rem;
 
     li {
       list-style: none;
-      border: 1px solid oklch(var(--color-tabs-inactive-border));
-      border-bottom: 1px solid oklch(var(--color-foreground));
-      color: oklch(var(--color-brand));
-      padding: 10px;
+      border-bottom: 1px solid oklch(var(--color-tabs-inactive-border));
+      padding: 0.25rem 0.75rem;
       margin: 0;
       position: relative;
 
@@ -1900,8 +1895,8 @@ li:has(> div > blockquote) {
       display: block;
       bottom: 0;
       left: 0;
-      width: 2rem;
-      border-bottom: 1px solid oklch(var(--color-foreground));
+      width: 1rem;
+      border-bottom: 1px solid oklch(var(--color-tabs-inactive-border));
     }
 
     &::after {
@@ -1912,18 +1907,17 @@ li:has(> div > blockquote) {
       left: 0;
       right: 0;
       width: 100%;
-      border-bottom: 1px solid oklch(var(--color-foreground));
+      border-bottom: 1px solid oklch(var(--color-tabs-inactive-border));
     }
   }
 
   .tab-contents {
     padding-block: 1rem;
-    border-bottom: 1px solid oklch(var(--color-foreground));
 
     .tab-content {
       display: none;
       width: 100%;
-      padding: 1rem;
+      padding: 0.5rem 1rem;
 
       --flow-gap: 2rem;
 

--- a/layouts/shortcodes/tabs.html
+++ b/layouts/shortcodes/tabs.html
@@ -9,7 +9,7 @@
         <input type="radio" name="{{$tab_set_id}}" id="{{$id}}" aria-hidden="true" checked="checked">
       {{- else -}}
         <input type="radio" name="{{$tab_set_id}}" id="{{$id}}" aria-hidden="true">
-      {{- end -}}  
+      {{- end -}}
 	{{- end -}}
 	<ul class="tab-labels" role="tablist" id="{{ $tab_set_id }}" data-testid="labels-{{ $tab_set_id }}">
 	  {{- range $i, $e := $tabs -}}
@@ -42,19 +42,8 @@
 <style>
   {{- range $i, $e := $tabs -}}
   	.tabs-container input[type="radio"]:checked:nth-of-type({{ add $i 1 }}) ~ .tab-labels li:nth-of-type({{ add $i 1 }}) {
-	  border: none;
-      border-top: 1px solid oklch(var(--color-foreground));
-      border-left: 1px solid oklch(var(--color-foreground));
-      border-bottom: none;
-      color: oklch(var(--color-foreground));
-
-	  + li {
-		border-left: 1px solid oklch(var(--color-foreground));
-	  }
-
-	  &:last-of-type {
-      	border-right: 1px solid oklch(var(--color-foreground));
-      }
+      border-bottom: 2px solid oklch(var(--color-brand));
+      color: oklch(var(--color-brand));
 	}
 
 	.tabs-container input[type="radio"]:checked:nth-of-type({{ add $i 1 }}) ~ .tab-contents div:nth-of-type({{ add $i 1 }}) {


### PR DESCRIPTION
### Proposed changes
Closes: nginxinc/docs-platform/issues/422

Notable changes:
- `--magrin-tab-group` typo
- padding changes
- no more `border-bottom` underline
- simpler inline styles in `tabs.html`

Before:
<img width="855" height="721" alt="Screenshot 2025-07-28 at 4 09 05 PM" src="https://github.com/user-attachments/assets/3d590986-2b76-4d9f-a1cc-887870fc3340" />

After:
<img width="881" height="680" alt="Screenshot 2025-07-28 at 4 08 43 PM" src="https://github.com/user-attachments/assets/f29c547c-067f-4d4f-93ac-b520c706a449" />

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
