### PR TITLE
Refactored margin naming syntax

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -1512,7 +1512,7 @@ a:hover {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  margin-top: 0.5rem;
+  margin-block-start: 0.5rem;
 
   .card-section {
     display: flex;
@@ -1732,7 +1732,7 @@ blockquote {
 }
 
 blockquote[data-grid="last-third"] {
-  margin-top: 0;
+  margin-block-start: 0;
 }
 
 @media (max-width: 55rem) {


### PR DESCRIPTION
### Proposed changes

Renamed instances of `margin-X`, where X is `top`, `bottom`, `left`, or `right` to use `margin-block-Y` or `margin-inline-Y`, where Y is `start` or `end`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
