### PR TITLE
Handle case of no inner for cards

### DIFF
--- a/exampleSite/content/test-product/_index.md
+++ b/exampleSite/content/test-product/_index.md
@@ -54,8 +54,6 @@ This is a compilation of all our shortcodes to show how they look, function, res
 
 {{<card-layout >}}
   {{<card-section title="NGINX" showAsCards="true" >}}
-    {{<card title="NGINX Plus" titleUrl="/nginx/" brandIcon="NGINX-Plus-product-icon-RGB.svg" >}}
-      Installing NGINX
-    {{</card >}}
+    {{<card title="NGINX Plus" titleUrl="/nginx/" brandIcon="NGINX-Plus-product-icon-RGB.svg" />}}
   {{</card-section >}}
 {{</card-layout >}}

--- a/layouts/shortcodes/card.html
+++ b/layouts/shortcodes/card.html
@@ -17,22 +17,22 @@
 {{- $isLanding := cond (eq $isLandingParam "true") "true" "false" -}}
 
 {{- /* Set up the positioning */ -}}
-{{ $dataGrid := "" }}
-{{ if eq $isFullSize "true" }}
-  {{ $dataGrid = "wide"}}
-{{ else if (eq $isLanding "true") }}
-  {{ $dataGrid = "third"}}
-{{ else }}
-  {{ $dataGrid = "half"}}
-{{ end }}
+{{- $dataGrid := "" -}}
+{{- if eq $isFullSize "true" -}}
+  {{- $dataGrid = "wide" -}}
+{{- else if (eq $isLanding "true") -}}
+  {{- $dataGrid = "third" -}}
+{{- else -}}
+  {{- $dataGrid = "half" -}}
+{{- end -}}
 
 {{- /* Build the url */ -}}
-{{ $url := printf "%s%s" .Page.Permalink $titleUrl }}
-{{ if eq (substr $titleUrl 0 1) "/" }}
-  {{ $url = printf "%s%s" .Site.BaseURL (substr $titleUrl 1) }}
-{{ else if (strings.Contains $titleUrl "https") }}
-  {{ $url = $titleUrl }}
-{{ end }}
+{{- $url := printf "%s%s" .Page.Permalink $titleUrl -}}
+{{- if eq (substr $titleUrl 0 1) "/" -}}
+  {{- $url = printf "%s%s" .Site.BaseURL (substr $titleUrl 1) -}}
+{{- else if (strings.Contains $titleUrl "https") -}}
+  {{- $url = $titleUrl -}}
+{{- end -}}
 
 {{- /* Validate that the parent is card-section and under 3 cards */ -}}
 {{- if (eq .Parent.Name "card-section") -}}
@@ -50,7 +50,9 @@
     {{- else -}}
       {{ errorf "Mainframe: Missing param 'title'" }}
     {{- end -}}
-    <div class="card-content">{{ .Inner }}</div>
+    {{- with .Inner -}}
+    <div class="card-content">{{ . }}</div>
+    {{- end -}}
   </div>
 </a>
 {{- else -}}


### PR DESCRIPTION
### Proposed changes

To better handle closing tags on `card` shortcode such as ```{{<card ... />}}```, the following need to be changed -

- Fix whitespace issues resulting in the following when rendered:
    <img width="827" height="243" alt="Screenshot 2025-07-28 at 3 22 27 PM" src="https://github.com/user-attachments/assets/92384d84-f575-476e-b2a8-567b562e62fd" />

- Better handle case where there is no `.Inner` due to the closing tag. This results in more centered header as seen below:

   Before: 
   <img width="1834" height="373" alt="Screenshot 2025-07-28 at 3 26 43 PM" src="https://github.com/user-attachments/assets/52c9fe7e-3625-411e-bd76-59cba6c2b0d2" />

   After:
  <img width="1864" height="374" alt="Screenshot 2025-07-28 at 3 26 26 PM" src="https://github.com/user-attachments/assets/bf67ed59-312f-4da7-bebf-bfccf5228164" />

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
