### PR TITLE
Feat: Add trace to deprecated shortcode warnings

### DIFF
--- a/layouts/shortcodes/before-you-begin.html
+++ b/layouts/shortcodes/before-you-begin.html
@@ -5,4 +5,4 @@
  "sideline" "false"
  "content" .Inner
 ) }}
-{{ warnf "'<before-you-begin></before-you-begin>' is being deprecated. Use generic 'call-out' shortcode instead."}}
+{{ warnf "'<before-you-begin></before-you-begin>' is being deprecated. Use generic 'call-out' shortcode instead. (%s)" .Position }}

--- a/layouts/shortcodes/note.html
+++ b/layouts/shortcodes/note.html
@@ -5,4 +5,4 @@
 "sideline" "false"
 "content" .Inner
 ) }}
-{{ warnf "'<note></note>' is being deprecated. Use generic 'call-out' shortcode instead."}}
+{{ warnf "'<note></note>' is being deprecated. Use generic 'call-out' shortcode instead. (%s)" .Position }}

--- a/layouts/shortcodes/see-also.html
+++ b/layouts/shortcodes/see-also.html
@@ -5,4 +5,4 @@
 "sideline" "false"
 "content" .Inner
 ) }}
-{{ warnf "'<see-also></see-also>' is being deprecated. Use generic 'call-out' shortcode instead."}}
+{{ warnf "'<see-also></see-also>' is being deprecated. Use generic 'call-out' shortcode instead. (%s)" .Position }}

--- a/layouts/shortcodes/tip.html
+++ b/layouts/shortcodes/tip.html
@@ -5,4 +5,4 @@
 "sideline" "false"
 "content" .Inner
 ) }}
-{{ warnf "'<tip></tip>' is being deprecated. Use generic 'call-out' shortcode instead."}}
+{{ warnf "'<tip></tip>' is being deprecated. Use generic 'call-out' shortcode instead. (%s)" .Position }}


### PR DESCRIPTION
### Proposed changes

Adds a location trace to shortcode deprecation warning messages for easier remediation. 

Mainframe also contains a deprecation warning for `<bootstrap-table>` that should include a trace but wasn't included in this changeset. 

Example Message:

```sh
WARN  '<note></note>' is being deprecated. Use generic 'call-out' shortcode instead. ("/src/content/nap-dos/monitoring/types-of-logs.md:18:1")
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
