### PR TITLE
Fix icon width on safari

### DIFF
--- a/assets/css/f5-hugo.css
+++ b/assets/css/f5-hugo.css
@@ -357,7 +357,7 @@ a.other-products-card:hover {
 .card-img,
 .card-img-top {
   flex: 0;
-  width: auto;
+  width: 40px;
   max-height: 40px;
   color: var(--nginx-green);
   margin-right: 5px;


### PR DESCRIPTION
### Proposed changes

Fixed issue of `auto` being set to 100% on Safari

Before:
<img width="1676" height="474" alt="Screenshot 2025-08-13 at 10 49 39 AM" src="https://github.com/user-attachments/assets/adf23caa-b465-4db9-a35f-4b3cc87d6e20" />

After:
<img width="1675" height="463" alt="Screenshot 2025-08-13 at 10 49 48 AM" src="https://github.com/user-attachments/assets/796da17d-8b6e-44b0-b52a-0163d480da05" />


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
