### PR TITLE
Default index pages

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -24,12 +24,26 @@
         {{ $hasCustomContent := index .Params "nd-landing-page" | default false }}
         {{ if $hasCustomContent }}
         {{ .Content }}
+
+        <!-- Default index page content -->
         {{ else }}
+
+    <h2> In this section </h2>
+    <div class="card-section featured-section">
+        <div class="card-section-content card-grid">
         {{ range .Pages.ByWeight }}
-          <h2>
-            <a href="{{ .Permalink }}">{{ .Title }}</a>
-          </h2>
+            <a href="{{ .Permalink }}" alt="{{ .Title }}" class="card" data-grid="first-two-thirds">
+            <div class="card-container">
+                <div class="card-header">
+                    <h2 class="card-title">{{ .Title }}</h2>
+                </div>
+                <div class="card-content">{{ .Description }}</div>
+            </div>
+            </a>
         {{ end }}
+        </div>
+    </div>
+
         {{ end }}
 
         <hr>


### PR DESCRIPTION
Adds basic card with title and description, for index pages with no custom content.
In most cases, the _only_ way to get these pages on `mainframe` is by clicking on the breadcrumb.
There are some links still going to these pages, so it's safer to having something nicer until we can remove them completely.
<img width="922" height="958" alt="Screenshot 2025-08-20 at 14 06 45" src="https://github.com/user-attachments/assets/415f7f84-7550-4537-a0f0-761e4a8df1ab" />


