### PR TITLE
Frontmatter: Add optional reading time

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -1523,6 +1523,11 @@ a:hover {
       display: block;
     }
   }
+
+  .content__reading-time {
+    font-size: var(--font-step--1);
+    color: oklch(var(--color-footer-text));
+  }
 }
 
 .headerlink {

--- a/exampleSite/content/nginx/installing-nginx-open-source.md
+++ b/exampleSite/content/nginx/installing-nginx-open-source.md
@@ -7,6 +7,7 @@ doctypes:
 title: Installing NGINX Open Source
 toc: true
 weight: 200
+nd-reading-time: true
 ---
 
 ![hero-graphic](/hero-graphic.webp)

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -14,6 +14,11 @@
         {{ partial "banner" .}}
 
         <h1>{{ .Title }}</h1>
+        <div class="content__reading-time">
+        {{ if index .Params "nd-reading-time" }}
+            {{ printf "~%d min read" .ReadingTime }}
+        {{ end }}
+        </div>
 
         {{ $content | safeHTML }}
 


### PR DESCRIPTION
Add optional "read time" using the `nd-reading-time` frontmatter.
Uses https://gohugo.io/methods/page/readingtime/ - Estimates can be configured based on reading WPM.

<img width="667" height="694" alt="Screenshot 2025-08-22 at 17 22 16" src="https://github.com/user-attachments/assets/2edea6df-549a-418f-b77f-da846795b41b" />


<img width="286" height="76" alt="Screenshot 2025-08-22 at 17 22 39" src="https://github.com/user-attachments/assets/a822ab7b-1bf0-43b4-9f55-82ae9c00dbc8" />
