### PR TITLE
ProductSelector: Open external links in a new tab

### DIFF
--- a/exampleSite/data/product-selector.yaml
+++ b/exampleSite/data/product-selector.yaml
@@ -3,6 +3,12 @@
     - title: "Test Product"
       url: "/test-product"
 
+- productGroup: Test External Links
+  products:
+    - title: "NGINX.org"
+      url: https://nginx.org/index.html
+      extUrl: true
+
 - productGroup: NGINX
   products:
     - title: "NGINX"

--- a/layouts/partials/sidebar-v2.html
+++ b/layouts/partials/sidebar-v2.html
@@ -51,7 +51,15 @@
                     <ul>
                       {{ $products := sort $group.products "productOrder" }}
                       {{ range $product := $products }}
-                        <li class="product-selector__product"><a href="{{ $product.url }}">{{ $product.title }}</a></li>
+                        <li class="product-selector__product">
+                          <a
+                            href="{{ $product.url }}"
+                            aria-label="{{ $product.title }} documentation"
+                            {{ if $product.extUrl }} target="_blank" {{ end }}
+                          >
+                            {{ $product.title }}
+                          </a>
+                        </li>
                       {{ end }}
                     </ul>
                   {{ end }}


### PR DESCRIPTION
### Proposed changes

Tweaks product selector schema to include an "extUrl" property. This property is then used in handling to assign `target="_blank"` when rendered.

Example:
```yaml
- productGroup: Test External Links
  products:
      - title: "NGINX.org"
        url: https://nginx.org/index.html
        extUrl: true
```

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
