### PR TITLE
ProductSelector: Regex match paths

### DIFF
--- a/layouts/partials/sidebar-v2.html
+++ b/layouts/partials/sidebar-v2.html
@@ -9,22 +9,23 @@
           </label>
         </div>
 
-        {{ $relPermalink := .RelPermalink }}
+        {{ $relPermalink := (urls.Parse .RelPermalink).Path }}
         {{ $currentProductTitle := "" }}
 
         {{ with index .Site.Data "product-selector" }}
           {{ range $group := . }}
             {{ range $product := $group.products }}
               {{ if not $product.extUrl }}
-              {{ warnf "$relPermalink: %s" $relPermalink }}
-              {{ warnf "$product.url: %s" $product.url }}
-                {{ if strings.Contains $relPermalink $product.url }}
+                {{ $escaped := replace $product.url "/" "\\/" }}
+                {{ $pattern := printf "/%s(/|$)" $escaped }}
+                {{ if strings.FindRE $pattern $relPermalink }}
                   {{ $currentProductTitle = $product.title }}
                 {{ end }}
               {{ end }}
             {{ end }}
           {{ end }}
         {{ end }}
+
 
 
         <div class="product-selector">


### PR DESCRIPTION
ProductSelector: Regex match paths

Fixes issues where `nginx-one` path would get incorrectly matched again `nginx` due the the naive `.Contains` usage.