### PR TITLE
Commercial: Add partial for commercial features

### DIFF
--- a/exampleSite/content/test-product/commerical/_index.md
+++ b/exampleSite/content/test-product/commerical/_index.md
@@ -1,0 +1,4 @@
+---
+title: Commercial
+description: Highlighting commerical pages
+---

--- a/exampleSite/content/test-product/commerical/commercial-feature.md
+++ b/exampleSite/content/test-product/commerical/commercial-feature.md
@@ -1,0 +1,9 @@
+---
+title: Commercial Feature
+description: Commercial Feature
+nd-commercial: true
+---
+
+The sidebar for this item should contain _Commercial_ to signifiy that it requires a comemrical subscription.
+
+This is managed by the `nd-commercial: true` in the frontmatter.

--- a/exampleSite/content/test-product/commerical/partial-commercial-feature.md
+++ b/exampleSite/content/test-product/commerical/partial-commercial-feature.md
@@ -1,0 +1,13 @@
+---
+title: Partial Commercial Feature
+description: Partial Commercial Feature
+nd-commercial-partial: true
+---
+
+The sidebar for this item should contain _Partial Commercial_ to signifiy that it requires a commercial subscription
+for a part of this page.
+
+For example, a module may have specific features or directives within, that
+require a commercial subscription, but the module itself can be used without it.
+
+This is managed by the `nd-commercial-partial: true` in the frontmatter.

--- a/layouts/partials/commercial-feature.html
+++ b/layouts/partials/commercial-feature.html
@@ -1,0 +1,7 @@
+{{ with .Params }}
+  {{ if (index . "nd-commercial") }}
+  - <em>Commercial</em>
+  {{ else if (index . "nd-commercial-partial") }}
+  - <em>Partial Commercial</em>
+  {{ end }}
+{{ end }}

--- a/layouts/partials/sidebar-list.html
+++ b/layouts/partials/sidebar-list.html
@@ -65,7 +65,7 @@
             aria-controls="{{ $tocID }}"
             id="{{ $linkID }}"
           >
-            <span>{{ $p.Title }}</span>
+            <span>{{ $p.Title }} {{ partial "commercial-feature.html" $p }}</span>
             <span class="sidebar__chevron sidebar__chevron--open">
               {{ partial "lucide" (dict "context" . "icon" "chevron-right") }}
             </span>
@@ -86,7 +86,7 @@
             class="sidebar__link {{ if $onPage }}sidebar__link--current{{ end }}"
             {{ if $onPage }}aria-current="page"{{ end }}
           >
-            {{ $p.Title }}
+              <span>{{ $p.Title }} {{ partial "commercial-feature.html" $p }}</span>
           </a>
         {{ end }}
       </li>


### PR DESCRIPTION
Commercial: Add partial for commercial features

For now, this literally adds the words "Commercial" and "Partial Commercial" based on frontmatter.
The partial should be easy to modify if we want it to be specific icons instead.

<img width="1056" height="339" alt="Screenshot 2025-09-04 at 10 45 46" src="https://github.com/user-attachments/assets/10b12d21-6ad4-42c3-87af-7fbeb19bdb61" />
