### PR TITLE
Callout: Fix side callout margin

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -2022,6 +2022,11 @@ blockquote {
   .callout-content {
     margin: 0;
   }
+
+  /* To help them align with text, side callouts should not have top margin*/
+  &[data-grid="last-third"] {
+    --margin-callout: 0 0 0 1rem;
+  }
 }
 
 blockquote.note {
@@ -2395,6 +2400,10 @@ ul .code-block {
 
 .banner {
   margin-block-start: 1rem;
+
+  blockquote {
+    margin-left: 0rem;
+  }
 }
 
 /* MARK: Images


### PR DESCRIPTION
Callout: Fix side callout margin

Handle banner styling

Before
<img width="611" height="190" alt="Screenshot 2025-09-04 at 15 51 19" src="https://github.com/user-attachments/assets/940645ff-f13a-4e9f-be7f-e238b57719f5" />


After
<img width="612" height="211" alt="Screenshot 2025-09-04 at 15 50 39" src="https://github.com/user-attachments/assets/8ea9f4b1-1021-4085-aede-dd8a5c3bc394" />
