### PR TITLE
Fix codeblock whitespace causing extra rendering

### DIFF
--- a/layouts/partials/callout.html
+++ b/layouts/partials/callout.html
@@ -35,11 +35,11 @@
 <blockquote class="{{ $class }}" data-grid="{{ $dataGrid }}">
   <div>
     <div class="call-out-type">
-      {{ partial "lucide" (dict "context" . "icon" $icon) .}}
+      {{ partial "lucide" (dict "context" . "icon" $icon) . }}
       {{ $title }}
     </div>
     <div class="callout-content">
-      {{ .content | markdownify }}
+      {{- .content | markdownify -}}
     </div>
   </div>
 </blockquote>


### PR DESCRIPTION
### Proposed changes

Fix issue with some of the HTML tags to be rendered as `code` blocks sometimes.

Before:
<img width="707" height="294" alt="Screenshot 2025-09-04 at 10 33 05 AM" src="https://github.com/user-attachments/assets/cda5caaf-37d0-4a48-931b-67bf8ab09cbd" />

After:
<img width="713" height="247" alt="Screenshot 2025-09-04 at 10 32 23 AM" src="https://github.com/user-attachments/assets/a7b20080-f58d-44c8-ab89-06c29e5e074e" />

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
