### PR TITLE
Biome: Set config to root, remove config path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 BIOME_BASE_CMD := $(if $(shell which biome),biome,npx @biomejs/biome@2.2.2)
-BIOME_CONFIG_PATH := --config-path="biome.json"
 WRITE_FLAG := --write
 
 .PHONY: list help
@@ -26,11 +25,11 @@ ifeq ($(BIOME_ARGS), write)
 endif
 
 biome-format:
-	$(BIOME_BASE_CMD) format $(BIOME_CONFIG_PATH) $(FLAG)
+	$(BIOME_BASE_CMD) format $(FLAG)
 biome-lint:
-	$(BIOME_BASE_CMD) lint $(BIOME_CONFIG_PATH) $(FLAG)
+	$(BIOME_BASE_CMD) lint $(FLAG)
 biome-all:
-	$(BIOME_BASE_CMD) check $(BIOME_CONFIG_PATH) $(FLAG)
+	$(BIOME_BASE_CMD) check $(FLAG)
 
 setup-pre-commit:
 	@if ! command -v pre-commit &> /dev/null; then \

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.2.2/schema.json",
-  "root": false,
+  "root": true,
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
Biome: Set config to root, remove config path

When `root` is true, and a config-path is set, biome errors out, which is why I had set `root` to false.
```
  ✖ Found a nested root configuration, but there's already a root configuration.
  
  ℹ The other configuration was found in .
  
  ℹ Use the migration command from the root of the project to update the configuration.
```
_Something_ changed in a recent version causing this, but I can't pin it down. 
Since we use the default config path anyway, there's no reason to specify a path, and at least from my testing, this make biome work as expected in vscode and zed.
