### PR TITLE
Breadcrumbs: Adjust list page handling to resolve awkward mobile spacing

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -426,12 +426,9 @@ ol li:last-child {
       "content"
       "footer";
 
-    .text-content {
-      margin-block-start: 1rem;
-    }
-
     .breadcrumb-layout {
       align-items: center;
+      display: flex;
       padding: var(--space-xs) 0;
 
       &::after {
@@ -1264,11 +1261,6 @@ main {
   }
 }
 
-/* Handles different flow-gap of list page  */
-.list-page.text-content {
-  grid-template-rows: calc(70px + var(--flow-gap)) max-content;
-}
-
 /* MARK: Qualtrics
 */
 
@@ -1917,6 +1909,7 @@ a:hover {
 
 .list-header-container {
   display: flex;
+  margin-top: var(--space-s);
   gap: 1.5rem;
   align-items: center;
   justify-content: start;

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,7 @@
 
 <main class="content" role="main" data-testid="content">
     <div data-cms-edit="content" class="text-content list-page">
-        <div class="breadcrumb-layout">
+        <div class="breadcrumb-layout" data-grid="wide">
         {{ if not .IsHome }}
             {{ if not (in .Params.display_breadcrumb "false" ) }}
             {{ partial "breadcrumb" .}}


### PR DESCRIPTION
### Proposed changes

* Resolves awkward spacing for breadcrumbs on mobile landing pages
* Removes grid template row property which was causing the weird sizing. Spacing provided by the grid-template-row property was replaced with margin.
* Also adjusts the breadcrumb-layout element to data-grid="wide", fixing an issue where bottom borders extend half the screen on intermediate breakpoints. 

### Before

<img width="567" height="969" alt="CleanShot 2025-09-09 at 15 16 47" src="https://github.com/user-attachments/assets/8becc6b6-9081-4ea5-9288-f09368e6bb9d" />

### After

<img width="458" height="969" alt="CleanShot 2025-09-09 at 15 17 23" src="https://github.com/user-attachments/assets/f468a556-8394-44e1-b330-04a7d2214c2a" />

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
