### PR TITLE
ProductSelector: Match product identifier exactly

### DIFF
--- a/layouts/partials/sidebar-v2.html
+++ b/layouts/partials/sidebar-v2.html
@@ -19,8 +19,13 @@
           {{ range $group := . }}
             {{ range $product := $group.products }}
               {{ if not $product.extUrl }}
-                {{ $escaped := replace $product.url "/" "\\/" }}
+                <!-- Remove any leading or trailing slashes for capture group handling                -->
+                {{ $escaped := strings.TrimPrefix "/" $product.url }}
+                {{ $escaped = strings.TrimSuffix "/" $escaped }}
+
+                {{ $escaped = replace $escaped "/" "\\/" }}
                 {{ $pattern := printf "/(%s)/" $escaped }}
+
                 {{ if strings.FindRE $pattern $normalizedPath }}
                   {{ $currentProductTitle = $product.title }}
                 {{ end }}


### PR DESCRIPTION
### Proposed changes

Resolve issues when a product ID is a subset of another by only matching exactly

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
