### PR TITLE
Fix overflowing title on product selector

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -802,6 +802,9 @@ ol li:last-child {
 
         .product-selector__toggle-text {
           font-weight: 500;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
         }
 
         .product-selector__chevron {

--- a/layouts/partials/sidebar-v2.html
+++ b/layouts/partials/sidebar-v2.html
@@ -40,7 +40,7 @@
             <details class="product-selector__section">
                 <summary class="product-selector__toggle">
 
-                    <span class="product-selector__toggle-text">
+                    <span class="product-selector__toggle-text" title="{{ if $currentProductTitle }}{{ $currentProductTitle }}{{else}}Product Documentation{{end}}">
                         {{ if $currentProductTitle }}
                             {{ $currentProductTitle }}
                         {{ else }}


### PR DESCRIPTION
### Proposed changes

Before (for text "NGINX One and everything bundled into one package"):
<img width="344" height="63" alt="Screenshot 2025-10-01 at 10 22 08 AM" src="https://github.com/user-attachments/assets/46aa1136-5cda-4688-bd2f-94069778036d" />

After:
<img width="347" height="85" alt="Screenshot 2025-10-01 at 10 23 12 AM" src="https://github.com/user-attachments/assets/a400b864-bab8-4e58-aec1-f82b2d5a20db" />


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
