### PR TITLE
Breadcrumb: Adjust 'Home' item to link to baseURL

### DIFF
--- a/layouts/partials/breadcrumb.html
+++ b/layouts/partials/breadcrumb.html
@@ -1,6 +1,8 @@
 <nav aria-label="breadcrumb" class="breadcrumb" data-grid="wide">
     <ol class="breadcrumb">
-        <li><a href="/" alt="NGINX Docs Home">Home</a></li>
+        <li>
+            <a href="{{ .Site.BaseURL }}">Home</a>
+        </li>
         {{- define "breadcrumb" -}}
         {{- with .Parent -}}
             {{- template "breadcrumb" . -}}


### PR DESCRIPTION
### Proposed changes

* Adjusts "Home" breadcrumb item to link to baseUrl instead of "/"

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
