### PR TITLE
Fix heading anchor link icon alignment

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -1760,7 +1760,6 @@ a:hover {
     .headerlink::before {
       display: flex;
       align-items: flex-start;
-      height: 100%;
     }
   }
 

--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -1760,6 +1760,7 @@ a:hover {
     .headerlink::before {
       display: flex;
       align-items: flex-start;
+      height: 100%;
     }
   }
 
@@ -1782,7 +1783,8 @@ a:hover {
 
 .headerlink {
   text-decoration: none;
-
+  position: relative;
+  display: flex;
   color: oklch(var(--color-foreground));
 }
 


### PR DESCRIPTION
### Proposed changes

Before:
<img width="1179" height="418" alt="Screenshot 2025-10-07 at 1 59 38 PM" src="https://github.com/user-attachments/assets/d78b9fb5-332d-43ff-8b1f-a8bdff9fd55f" />

After:
<img width="1180" height="422" alt="Screenshot 2025-10-07 at 1 59 52 PM" src="https://github.com/user-attachments/assets/7518b6b9-fd0f-4279-bdfe-420362f9fe60" />

Edge case (mulit-line text):
<img width="1176" height="447" alt="Screenshot 2025-10-07 at 2 20 59 PM" src="https://github.com/user-attachments/assets/6478ea06-0f1f-487a-9f24-f28739d6c703" />


### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
