### PR TITLE
feat: add data-table shortcode for JSON/CSV/YAML-backed tables

### DIFF
--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -134,14 +134,9 @@ textarea:not([rows]) {
   /* More info: https://docs.coveo.com/en/atomic/latest/usage/themes-and-visual-customization/ */
 
   /* biome-ignore lint: Coveo override */
-  --atomic-primary: oklch(
-    var(--color-brand)
-  ) !important; /* Adjust the primary color */
+  --atomic-primary: oklch(var(--color-brand)) !important; /* Adjust the primary color */
   /* biome-ignore lint: necessary override */
-  --atomic-ring-primary: oklch(
-    var(--color-brand) /
-    0.4
-  ) !important; /* Adjust the focus color */
+  --atomic-ring-primary: oklch(var(--color-brand) / 0.4) !important; /* Adjust the focus color */
   /* biome-ignore lint: necessary override */
   --atomic-primary-light: oklch(var(--color-brand)) !important;
   --atomic-background: oklch(0.9911 0 0) !important;

--- a/assets/css/v2/style.css
+++ b/assets/css/v2/style.css
@@ -134,9 +134,14 @@ textarea:not([rows]) {
   /* More info: https://docs.coveo.com/en/atomic/latest/usage/themes-and-visual-customization/ */
 
   /* biome-ignore lint: Coveo override */
-  --atomic-primary: oklch(var(--color-brand)) !important; /* Adjust the primary color */
+  --atomic-primary: oklch(
+    var(--color-brand)
+  ) !important; /* Adjust the primary color */
   /* biome-ignore lint: necessary override */
-  --atomic-ring-primary: oklch(var(--color-brand) / 0.4) !important; /* Adjust the focus color */
+  --atomic-ring-primary: oklch(
+    var(--color-brand) /
+    0.4
+  ) !important; /* Adjust the focus color */
   /* biome-ignore lint: necessary override */
   --atomic-primary-light: oklch(var(--color-brand)) !important;
   --atomic-background: oklch(0.9911 0 0) !important;
@@ -2001,6 +2006,77 @@ table hr {
   margin-right: -10px;
   margin-left: -10px;
   width: auto;
+}
+
+/* MARK: Data Tables
+*/
+
+.data-table-wrapper {
+  --dt-header-bg: oklch(var(--color-foreground) / 5%);
+  --dt-focus-ring: oklch(var(--color-foreground) / 40%);
+
+  margin-block: var(--margin-table);
+}
+
+/* Sortable column headers */
+.data-table-wrapper th[data-column] {
+  cursor: pointer;
+  user-select: none;
+  white-space: nowrap;
+
+  &:hover {
+    background: var(--dt-header-bg);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--dt-focus-ring);
+    outline-offset: -2px;
+  }
+}
+
+.data-table-th-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+/* Sort icons: three Lucide SVGs per header, toggled by aria-sort */
+.data-table-sort-icon {
+  display: none;
+  line-height: 0;
+
+  & .lucide {
+    width: 0.85em;
+    height: 0.85em;
+    vertical-align: middle;
+  }
+}
+
+.data-table-sort-icon--none {
+  display: inline-flex;
+  opacity: 0.35;
+}
+
+th[aria-sort="ascending"] .data-table-sort-icon--none,
+th[aria-sort="descending"] .data-table-sort-icon--none {
+  display: none;
+}
+
+th[aria-sort="ascending"] .data-table-sort-icon--asc {
+  display: inline-flex;
+  opacity: 1;
+}
+
+th[aria-sort="descending"] .data-table-sort-icon--desc {
+  display: inline-flex;
+  opacity: 1;
+}
+
+.data-table-noscript {
+  font-size: var(--step--1);
+  font-style: italic;
+  color: oklch(var(--color-foreground) / 60%);
+  margin-block-start: 0.5rem;
 }
 
 /* MARK: Callouts

--- a/assets/js/data-table.js
+++ b/assets/js/data-table.js
@@ -99,6 +99,15 @@
   }
 
   /**
+   * Check whether a string is strictly numeric (rejects partial parses like "100/min").
+   * @param {string} s
+   * @returns {boolean}
+   */
+  function isNumeric(s) {
+    return s !== '' && !Number.isNaN(Number(s));
+  }
+
+  /**
    * Sort rows and update the DOM.
    */
   function render(tbody, allRows, colIndex, state) {
@@ -108,20 +117,27 @@
       const idx = colIndex[state.sortCol];
       const dir = state.sortDir === 'desc' ? -1 : 1;
 
-      rows = [...rows].sort((a, b) => {
-        const aCell = a.querySelectorAll('td')[idx];
-        const bCell = b.querySelectorAll('td')[idx];
-        const aText = aCell?.textContent?.trim() || '';
-        const bText = bCell?.textContent?.trim() || '';
+      // Pre-cache cell text to avoid DOM queries inside the comparator
+      const textCache = new Map();
+      for (const row of allRows) {
+        const cell = row.querySelectorAll('td')[idx];
+        textCache.set(row, cell?.textContent?.trim() || '');
+      }
 
-        // Try numeric comparison first
-        const aNum = Number.parseFloat(aText);
-        const bNum = Number.parseFloat(bText);
-        if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) {
-          return (aNum - bNum) * dir;
+      // Decide comparison mode once for the whole column:
+      // only use numeric sort when every non-empty value is a strict number.
+      const useNumeric = [...textCache.values()].every(
+        (v) => v === '' || isNumeric(v)
+      );
+
+      rows = [...rows].sort((a, b) => {
+        const aText = textCache.get(a);
+        const bText = textCache.get(b);
+
+        if (useNumeric) {
+          return (Number(aText) - Number(bText)) * dir;
         }
 
-        // Fall back to locale-aware string comparison
         return (
           aText.localeCompare(bText, undefined, { sensitivity: 'base' }) * dir
         );
@@ -129,13 +145,7 @@
     }
 
     // Update DOM -- clear tbody and re-append in order
-    while (tbody.firstChild) {
-      tbody.removeChild(tbody.firstChild);
-    }
-
-    for (const row of rows) {
-      tbody.appendChild(row);
-    }
+    tbody.replaceChildren(...rows);
   }
 
   // Initialize when DOM is ready

--- a/assets/js/data-table.js
+++ b/assets/js/data-table.js
@@ -1,0 +1,147 @@
+/**
+ * data-table.js
+ * Progressive enhancement for data-table shortcode.
+ * Adds column sorting to server-rendered HTML tables.
+ *
+ * No-JS fallback: tables remain fully readable without this script.
+ */
+
+(() => {
+  const SORT_ASC = 'ascending';
+  const SORT_DESC = 'descending';
+
+  /**
+   * Initialize all data-table instances on the page.
+   */
+  function initAll() {
+    const wrappers = document.querySelectorAll('.data-table-wrapper');
+    for (const wrapper of wrappers) {
+      initTable(wrapper);
+    }
+  }
+
+  /**
+   * Initialize a single data-table instance.
+   * @param {HTMLElement} wrapper - The .data-table-wrapper element
+   */
+  function initTable(wrapper) {
+    const table = wrapper.querySelector('table');
+    if (!table) return;
+
+    const thead = table.querySelector('thead');
+    const tbody = table.querySelector('tbody');
+    if (!thead || !tbody) return;
+
+    const headers = Array.from(thead.querySelectorAll('th[data-column]'));
+
+    // State
+    const state = {
+      sortCol: wrapper.dataset.defaultSort || null,
+      sortDir: wrapper.dataset.defaultSortDir || 'asc',
+    };
+
+    // Cache original rows
+    const allRows = Array.from(tbody.querySelectorAll('tr'));
+
+    // Build column index map
+    const colIndex = {};
+    for (let i = 0; i < headers.length; i++) {
+      colIndex[headers[i].dataset.column] = i;
+    }
+
+    // --- Sort controls ---
+    for (const th of headers) {
+      th.setAttribute('tabindex', '0');
+      th.setAttribute('role', 'columnheader');
+
+      const handleSort = () => {
+        const col = th.dataset.column;
+        if (state.sortCol === col) {
+          state.sortDir = state.sortDir === 'asc' ? 'desc' : 'asc';
+        } else {
+          state.sortCol = col;
+          state.sortDir = 'asc';
+        }
+        updateSortIndicators(headers, state);
+        render(tbody, allRows, colIndex, state);
+      };
+
+      th.addEventListener('click', handleSort);
+      th.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleSort();
+        }
+      });
+    }
+
+    // Set initial sort indicators
+    updateSortIndicators(headers, state);
+  }
+
+  /**
+   * Update sort direction indicators on column headers.
+   * Icons are rendered by Hugo (Lucide SVGs) and toggled via CSS
+   * based on the aria-sort attribute. JS only manages aria-sort.
+   */
+  function updateSortIndicators(headers, state) {
+    for (const th of headers) {
+      const col = th.dataset.column;
+      if (col === state.sortCol) {
+        th.setAttribute(
+          'aria-sort',
+          state.sortDir === 'desc' ? SORT_DESC : SORT_ASC
+        );
+      } else {
+        th.removeAttribute('aria-sort');
+      }
+    }
+  }
+
+  /**
+   * Sort rows and update the DOM.
+   */
+  function render(tbody, allRows, colIndex, state) {
+    let rows = allRows;
+
+    if (state.sortCol && colIndex[state.sortCol] !== undefined) {
+      const idx = colIndex[state.sortCol];
+      const dir = state.sortDir === 'desc' ? -1 : 1;
+
+      rows = [...rows].sort((a, b) => {
+        const aCell = a.querySelectorAll('td')[idx];
+        const bCell = b.querySelectorAll('td')[idx];
+        const aText = aCell?.textContent?.trim() || '';
+        const bText = bCell?.textContent?.trim() || '';
+
+        // Try numeric comparison first
+        const aNum = Number.parseFloat(aText);
+        const bNum = Number.parseFloat(bText);
+        if (!Number.isNaN(aNum) && !Number.isNaN(bNum)) {
+          return (aNum - bNum) * dir;
+        }
+
+        // Fall back to locale-aware string comparison
+        return (
+          aText.localeCompare(bText, undefined, { sensitivity: 'base' }) * dir
+        );
+      });
+    }
+
+    // Update DOM -- clear tbody and re-append in order
+    while (tbody.firstChild) {
+      tbody.removeChild(tbody.firstChild);
+    }
+
+    for (const row of rows) {
+      tbody.appendChild(row);
+    }
+  }
+
+  // Initialize when DOM is ready
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initAll);
+  } else {
+    initAll();
+  }
+})();

--- a/exampleSite/assets/data/api-endpoints.json
+++ b/exampleSite/assets/data/api-endpoints.json
@@ -1,0 +1,122 @@
+[
+  {
+    "endpoint": "/api/v1/users",
+    "method": "GET",
+    "description": "List all users with optional pagination",
+    "auth": "Bearer token",
+    "rate_limit": "100/min",
+    "status": "stable"
+  },
+  {
+    "endpoint": "/api/v1/users/{id}",
+    "method": "GET",
+    "description": "Get a single user by ID",
+    "auth": "Bearer token",
+    "rate_limit": "200/min",
+    "status": "stable"
+  },
+  {
+    "endpoint": "/api/v1/users",
+    "method": "POST",
+    "description": "Create a new user",
+    "auth": "Bearer token",
+    "rate_limit": "50/min",
+    "status": "stable"
+  },
+  {
+    "endpoint": "/api/v1/users/{id}",
+    "method": "PUT",
+    "description": "Update an existing user",
+    "auth": "Bearer token",
+    "rate_limit": "50/min",
+    "status": "stable"
+  },
+  {
+    "endpoint": "/api/v1/users/{id}",
+    "method": "DELETE",
+    "description": "Delete a user",
+    "auth": "Admin token",
+    "rate_limit": "20/min",
+    "status": "stable"
+  },
+  {
+    "endpoint": "/api/v1/groups",
+    "method": "GET",
+    "description": "List all groups",
+    "auth": "Bearer token",
+    "rate_limit": "100/min",
+    "status": "stable"
+  },
+  {
+    "endpoint": "/api/v1/groups/{id}/members",
+    "method": "GET",
+    "description": "List members of a group",
+    "auth": "Bearer token",
+    "rate_limit": "100/min",
+    "status": "stable"
+  },
+  {
+    "endpoint": "/api/v2/analytics",
+    "method": "GET",
+    "description": "Retrieve analytics data with date range filtering",
+    "auth": "Bearer token",
+    "rate_limit": "30/min",
+    "status": "beta"
+  },
+  {
+    "endpoint": "/api/v2/analytics/export",
+    "method": "POST",
+    "description": "Export analytics data to CSV or PDF",
+    "auth": "Admin token",
+    "rate_limit": "5/min",
+    "status": "beta"
+  },
+  {
+    "endpoint": "/api/v1/health",
+    "method": "GET",
+    "description": "Health check endpoint",
+    "auth": "None",
+    "rate_limit": "unlimited",
+    "status": "stable"
+  },
+  {
+    "endpoint": "/api/v1/config",
+    "method": "GET",
+    "description": "Get current server configuration",
+    "auth": "Admin token",
+    "rate_limit": "10/min",
+    "status": "stable"
+  },
+  {
+    "endpoint": "/api/v1/config",
+    "method": "PATCH",
+    "description": "Update server configuration",
+    "auth": "Admin token",
+    "rate_limit": "5/min",
+    "status": "stable"
+  },
+  {
+    "endpoint": "/api/v2/certificates",
+    "method": "GET",
+    "description": "List SSL/TLS certificates",
+    "auth": "Bearer token",
+    "rate_limit": "50/min",
+    "status": "beta"
+  },
+  {
+    "endpoint": "/api/v2/certificates",
+    "method": "POST",
+    "description": "Upload a new SSL/TLS certificate",
+    "auth": "Admin token",
+    "rate_limit": "10/min",
+    "status": "beta"
+  },
+  {
+    "endpoint": "/api/v1/upstreams",
+    "method": "GET",
+    "description": "List all upstream server groups",
+    "auth": "Bearer token",
+    "rate_limit": "100/min",
+    "status": "stable"
+  }
+]

--- a/exampleSite/assets/data/data-table-params.csv
+++ b/exampleSite/assets/data/data-table-params.csv
@@ -1,7 +1,7 @@
 Parameter,Required,Default,Description
-path,Yes,,"Path to the data file relative to assets/ (e.g. /data/endpoints.json). The leading / is conventional but optional."
+path,Yes,,"Path to the data file. Looks in the page bundle first, then the assets/ directory (e.g. /data/endpoints.json)."
 interactive,No,false,Set to true to enable client-side column sorting
-sort,No,,"Sort column and direction, applied at build time. Works with or without interactive. Format: column_name or column_name:asc or column_name:desc."
+sort,No,,"Sort column and direction, applied at build time. Works with or without interactive. Format: column_name or column_name:asc or column_name:desc. Warns if the column does not exist or the direction is invalid."
 columns,No,all,"Comma-separated list of columns to display, in the order listed. Also controls column order for JSON/YAML sources where the default is alphabetical."
 hide,No,,"Comma-separated list of columns to exclude. If both columns and hide are set, columns is applied first."
 labels,No,,"Column header overrides in key:Label format, comma-separated (e.g. rate_limit:Throttle)."

--- a/exampleSite/assets/data/data-table-params.csv
+++ b/exampleSite/assets/data/data-table-params.csv
@@ -1,9 +1,11 @@
 Parameter,Required,Default,Description
-path,Yes,,Path to the data file relative to assets/ (e.g. /data/endpoints.json)
+path,Yes,,"Path to the data file relative to assets/ (e.g. /data/endpoints.json). The leading / is conventional but optional."
 interactive,No,false,Set to true to enable client-side column sorting
-sort,No,,Default sort column. Append :asc or :desc for direction (e.g. name:desc)
-columns,No,all,Comma-separated list of columns to display in the given order
-hide,No,,Comma-separated list of columns to exclude
-labels,No,,Column header overrides in key:Label format comma-separated (e.g. rate_limit:Throttle)
+sort,No,,"Sort column and direction, applied at build time. Works with or without interactive. Format: column_name or column_name:asc or column_name:desc."
+columns,No,all,"Comma-separated list of columns to display, in the order listed. Also controls column order for JSON/YAML sources where the default is alphabetical."
+hide,No,,"Comma-separated list of columns to exclude. If both columns and hide are set, columns is applied first."
+labels,No,,"Column header overrides in key:Label format, comma-separated (e.g. rate_limit:Throttle)."
 variant,No,wide,Layout width: wide (full content area) or narrow (two-thirds)
 theme,No,bordered,Table style: bordered (borders and striped rows) or borderless (clean minimal look)
+humanize,No,true,"Humanize and title-case JSON/YAML keys for headers (e.g. rate_limit becomes Rate Limit). Has no effect on CSV sources. Set to false for raw keys."
+markdownify,No,false,"Process cell values as markdown. Enables bold, italic, links, inline code, etc. Raw HTML in data will also be rendered -- use only with trusted data."

--- a/exampleSite/assets/data/data-table-params.csv
+++ b/exampleSite/assets/data/data-table-params.csv
@@ -1,0 +1,8 @@
+Parameter,Required,Default,Description
+path,Yes,,Path to the data file relative to assets/ (e.g. /data/endpoints.json)
+interactive,No,false,Set to true to enable client-side column sorting
+sort,No,,Default sort column. Append :asc or :desc for direction (e.g. name:desc)
+columns,No,all,Comma-separated list of columns to display in the given order
+hide,No,,Comma-separated list of columns to exclude
+labels,No,,Column header overrides in key:Label format comma-separated (e.g. rate_limit:Throttle)
+variant,No,wide,Layout width: wide (full content area) or narrow (two-thirds)

--- a/exampleSite/assets/data/data-table-params.csv
+++ b/exampleSite/assets/data/data-table-params.csv
@@ -6,3 +6,4 @@ columns,No,all,Comma-separated list of columns to display in the given order
 hide,No,,Comma-separated list of columns to exclude
 labels,No,,Column header overrides in key:Label format comma-separated (e.g. rate_limit:Throttle)
 variant,No,wide,Layout width: wide (full content area) or narrow (two-thirds)
+theme,No,bordered,Table style: bordered (borders and striped rows) or borderless (clean minimal look)

--- a/exampleSite/assets/data/edge-cases.json
+++ b/exampleSite/assets/data/edge-cases.json
@@ -1,0 +1,18 @@
+[
+  {
+    "col:with:colons": "value:with:colons",
+    "col,with,commas": "value,with,commas",
+    "normal": "nothing special",
+    "html": "<a href=\"https://example.com\">link</a>",
+    "markdown": "**bold** and [a link](https://example.com)",
+    "shortcode": "{{< ref \"/docs\" >}}"
+  },
+  {
+    "col:with:colons": "another:value",
+    "col,with,commas": "a, b, c",
+    "normal": "plain text",
+    "html": "<script>alert(1)</script>",
+    "markdown": "Supports `inline code` and *emphasis*",
+    "shortcode": "{{< data-table path=\"evil\" >}}"
+  }
+]

--- a/exampleSite/assets/data/release-matrix.csv
+++ b/exampleSite/assets/data/release-matrix.csv
@@ -1,0 +1,11 @@
+Version,Release Date,Status,NGINX Plus,OS Support,EOL Date
+3.2.0,2025-09-15,current,R33,Ubuntu 24.04 / RHEL 9 / Debian 12,2026-09-15
+3.1.2,2025-06-10,supported,R32,Ubuntu 22.04 / RHEL 9 / Debian 12,2026-06-10
+3.1.1,2025-04-22,supported,R32,Ubuntu 22.04 / RHEL 9 / Debian 12,2026-04-22
+3.1.0,2025-02-01,supported,R31,Ubuntu 22.04 / RHEL 9 / Debian 11,2026-02-01
+3.0.3,2024-11-18,supported,R31,Ubuntu 22.04 / RHEL 8 / Debian 11,2025-11-18
+3.0.2,2024-09-05,eol,R30,Ubuntu 22.04 / RHEL 8 / Debian 11,2025-09-05
+3.0.1,2024-07-12,eol,R30,Ubuntu 22.04 / RHEL 8 / Debian 11,2025-07-12
+3.0.0,2024-05-01,eol,R30,Ubuntu 22.04 / RHEL 8 / Debian 11,2025-05-01
+2.9.1,2024-02-15,eol,R29,Ubuntu 20.04 / RHEL 8 / Debian 11,2025-02-15
+2.9.0,2023-12-01,eol,R29,Ubuntu 20.04 / RHEL 8 / Debian 10,2024-12-01

--- a/exampleSite/content/theme-overview/data-tables.md
+++ b/exampleSite/content/theme-overview/data-tables.md
@@ -20,11 +20,11 @@ Setting `interactive="true"` progressively enhances the table with client-side c
 
 ## Data formats
 
-Place data files anywhere inside your project's `assets/` directory. The `path` parameter is relative to `assets/`.
+Place data files anywhere inside your project's `assets/` directory. The `path` parameter is relative to `assets/` and conventionally starts with a `/` (e.g., `/data/endpoints.json`).
 
 ### JSON
 
-An array of objects. Keys become column headers, transformed with `humanize` and `title` (e.g., `rate_limit` becomes "Rate Limit").
+An array of objects. Keys become column headers, transformed with `humanize` and `title` by default (e.g., `rate_limit` becomes "Rate Limit"). Columns are sorted **alphabetically** -- use the `columns` parameter to control display order.
 
 ```json
 [
@@ -35,7 +35,7 @@ An array of objects. Keys become column headers, transformed with `humanize` and
 
 ### CSV
 
-Standard CSV with a header row. **Headers are used exactly as written** -- no transformation is applied.
+Standard CSV with a header row. Headers are used exactly as written -- no transformation is applied. Columns appear in file order. Quoted fields with commas and escaped quotes are handled per RFC 4180.
 
 ```text
 Endpoint,Method,Status
@@ -45,7 +45,7 @@ Endpoint,Method,Status
 
 ### YAML
 
-An array of objects, same structure as JSON. Keys are transformed the same way as JSON.
+An array of objects, same structure as JSON. Keys are transformed and sorted the same way.
 
 ```yaml
 - endpoint: /api/v1/users
@@ -62,7 +62,7 @@ An array of objects, same structure as JSON. Keys are transformed the same way a
 
 ### Static table (default)
 
-The simplest usage -- renders all columns from a JSON file as a static table.
+The simplest usage -- renders all columns from a JSON file as a static table. Columns appear in alphabetical order.
 
 ```text
 {{</* data-table path="/data/api-endpoints.json" */>}}
@@ -70,19 +70,19 @@ The simplest usage -- renders all columns from a JSON file as a static table.
 
 {{< data-table path="/data/api-endpoints.json" >}}
 
-### Selecting columns
+### Selecting columns and controlling order
 
-Use `columns` to show only specific columns, in the order listed.
+Use `columns` to choose which columns to display, in the exact order listed. This is especially useful for JSON and YAML sources where the default order is alphabetical.
 
 ```text
-{{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,status" */>}}
+{{</* data-table path="/data/api-endpoints.json" columns="status,endpoint,method" */>}}
 ```
 
-{{< data-table path="/data/api-endpoints.json" columns="endpoint,method,status" >}}
+{{< data-table path="/data/api-endpoints.json" columns="status,endpoint,method" >}}
 
 ### Hiding columns
 
-Use `hide` to remove specific columns while keeping all others.
+Use `hide` to remove specific columns while keeping all others in their default order. If both `columns` and `hide` are set, `columns` is applied first, then `hide` removes from that subset.
 
 ```text
 {{</* data-table path="/data/api-endpoints.json" hide="auth,rate_limit" */>}}
@@ -92,17 +92,37 @@ Use `hide` to remove specific columns while keeping all others.
 
 ### Overriding column headers
 
-Use `labels` to override auto-generated headers. The format is `key:Display Label` pairs, comma-separated.
+Use `labels` to override auto-generated headers. The format is `key:Display Label` pairs, comma-separated. Unescaped colons in label values are preserved (e.g., `key:Prefix: Suffix` produces the label "Prefix: Suffix").
 
 ```text
-{{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,rate_limit" labels="rate_limit:Throttle" */>}}
+{{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,rate_limit" labels="endpoint:API Path,rate_limit:Rate Limit (req/min)" */>}}
 ```
 
-{{< data-table path="/data/api-endpoints.json" columns="endpoint,method,rate_limit" labels="rate_limit:Throttle" >}}
+{{< data-table path="/data/api-endpoints.json" columns="endpoint,method,rate_limit" labels="endpoint:API Path,rate_limit:Rate Limit (req/min)" >}}
+
+### Raw keys (humanize disabled)
+
+Set `humanize="false"` to display JSON/YAML keys verbatim instead of applying humanize and title case. This has no effect on CSV sources, which always use headers as-is.
+
+```text
+{{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,status" humanize="false" */>}}
+```
+
+{{< data-table path="/data/api-endpoints.json" columns="endpoint,method,status" humanize="false" >}}
+
+### CSV source
+
+CSV headers appear exactly as written in the file.
+
+```text
+{{</* data-table path="/data/release-matrix.csv" */>}}
+```
+
+{{< data-table path="/data/release-matrix.csv" >}}
 
 ### Narrow variant
 
-Use `variant="narrow"` to constrain the table to two-thirds width.
+Use `variant="narrow"` to constrain the table to two-thirds of the content area.
 
 ```text
 {{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,status" variant="narrow" */>}}
@@ -120,25 +140,15 @@ Use `theme="borderless"` for a clean, minimal table without borders or row strip
 
 {{< data-table path="/data/api-endpoints.json" columns="endpoint,method,status" theme="borderless" >}}
 
-### Borderless with sorting
+### Static sort
 
-Combine `theme="borderless"` with `interactive="true"` for a minimal sortable table.
-
-```text
-{{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,status" theme="borderless" interactive="true" sort="endpoint:asc" */>}}
-```
-
-{{< data-table path="/data/api-endpoints.json" columns="endpoint,method,status" theme="borderless" interactive="true" sort="endpoint:asc" >}}
-
-### CSV source
-
-CSV headers appear exactly as written in the file.
+Use `sort` to order rows at build time. This works on static tables without `interactive`.
 
 ```text
-{{</* data-table path="/data/release-matrix.csv" */>}}
+{{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,status" sort="endpoint:desc" */>}}
 ```
 
-{{< data-table path="/data/release-matrix.csv" >}}
+{{< data-table path="/data/api-endpoints.json" columns="endpoint,method,status" sort="endpoint:desc" >}}
 
 ### Sortable table
 
@@ -152,7 +162,7 @@ Add `interactive="true"` to enable clickable column headers. Click a header to s
 
 ### Sortable with a default sort
 
-Use `sort` to set the initial sort column. Append `:asc` or `:desc` for direction (default is ascending).
+Combine `sort` with `interactive="true"` to set the initial sort column and direction. The sort indicator will reflect the initial state.
 
 ```text
 {{</* data-table path="/data/release-matrix.csv" interactive="true" sort="Version:desc" */>}}
@@ -160,8 +170,73 @@ Use `sort` to set the initial sort column. Append `:asc` or `:desc` for directio
 
 {{< data-table path="/data/release-matrix.csv" interactive="true" sort="Version:desc" >}}
 
+### Borderless with sorting
+
+Combine `theme="borderless"` with `interactive="true"` for a minimal sortable table.
+
+```text
+{{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,status" theme="borderless" interactive="true" sort="endpoint:asc" */>}}
+```
+
+{{< data-table path="/data/api-endpoints.json" columns="endpoint,method,status" theme="borderless" interactive="true" sort="endpoint:asc" >}}
+
+### Markdown in cells
+
+Set `markdownify="true"` to process cell values as markdown. Bold, italic, links, and inline code all render as formatted text.
+
+```text
+{{</* data-table path="/data/edge-cases.json" columns="markdown,normal" markdownify="true" */>}}
+```
+
+{{< data-table path="/data/edge-cases.json" columns="markdown,normal" markdownify="true" >}}
+
+{{< caution >}}
+Enabling `markdownify` also causes raw HTML in data values to be rendered as HTML, not escaped. Only use this with trusted data sources.
+{{< /caution >}}
+
+---
+
+## Special characters
+
+If your column names contain commas or colons, use `\,` and `\:` escape sequences in the `columns`, `hide`, `labels`, and `sort` parameters.
+
+### Selecting columns with special characters
+
+```text
+{{</* data-table path="/data/edge-cases.json" columns="col\:with\:colons,col\,with\,commas,normal" */>}}
+```
+
+{{< data-table path="/data/edge-cases.json" columns="col\:with\:colons,col\,with\,commas,normal" >}}
+
+### Label overrides with special characters
+
+Escape sequences work in both the key and value portions of `labels`.
+
+```text
+{{</* data-table path="/data/edge-cases.json" columns="col\:with\:colons,col\,with\,commas,normal" labels="col\:with\:colons:Colons\: In Key,col\,with\,commas:Commas\, In Key,normal:Just Normal" */>}}
+```
+
+{{< data-table path="/data/edge-cases.json" columns="col\:with\:colons,col\,with\,commas,normal" labels="col\:with\:colons:Colons\: In Key,col\,with\,commas:Commas\, In Key,normal:Just Normal" >}}
+
+### Sorting and hiding with special characters
+
+```text
+{{</* data-table path="/data/edge-cases.json" columns="col\:with\:colons,col\,with\,commas,normal" interactive="true" sort="col\:with\:colons:desc" */>}}
+```
+
+{{< data-table path="/data/edge-cases.json" columns="col\:with\:colons,col\,with\,commas,normal" interactive="true" sort="col\:with\:colons:desc" >}}
+
+```text
+{{</* data-table path="/data/edge-cases.json" hide="col\:with\:colons,col\,with\,commas" */>}}
+```
+
+{{< data-table path="/data/edge-cases.json" hide="col\:with\:colons,col\,with\,commas" >}}
+
 ---
 
 ## Limitations
 
-Cell values are rendered as **plain text only**. Markdown syntax, HTML tags, and shortcode calls in data values are not processed -- they appear as literal strings in the output. If you need rich formatting in a table, use a standard Markdown table or the `table` shortcode instead.
+- **Plain text by default.** Cell values are rendered as escaped plain text. Markdown syntax, HTML tags, and shortcode invocations appear as literal strings. Set `markdownify="true"` to opt in to markdown processing.
+- **No per-column markdownify.** The `markdownify` flag applies to all cells. There is no way to enable it for individual columns.
+- **Column ordering.** JSON and YAML columns are sorted alphabetically. Use `columns` to set a specific order. CSV columns always follow file order.
+- **Missing values.** If a JSON or YAML row is missing a key that other rows define, the cell renders as empty.

--- a/exampleSite/content/theme-overview/data-tables.md
+++ b/exampleSite/content/theme-overview/data-tables.md
@@ -110,6 +110,26 @@ Use `variant="narrow"` to constrain the table to two-thirds width.
 
 {{< data-table path="/data/api-endpoints.json" columns="endpoint,method,status" variant="narrow" >}}
 
+### Borderless theme
+
+Use `theme="borderless"` for a clean, minimal table without borders or row striping.
+
+```text
+{{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,status" theme="borderless" */>}}
+```
+
+{{< data-table path="/data/api-endpoints.json" columns="endpoint,method,status" theme="borderless" >}}
+
+### Borderless with sorting
+
+Combine `theme="borderless"` with `interactive="true"` for a minimal sortable table.
+
+```text
+{{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,status" theme="borderless" interactive="true" sort="endpoint:asc" */>}}
+```
+
+{{< data-table path="/data/api-endpoints.json" columns="endpoint,method,status" theme="borderless" interactive="true" sort="endpoint:asc" >}}
+
 ### CSV source
 
 CSV headers appear exactly as written in the file.
@@ -139,3 +159,9 @@ Use `sort` to set the initial sort column. Append `:asc` or `:desc` for directio
 ```
 
 {{< data-table path="/data/release-matrix.csv" interactive="true" sort="Version:desc" >}}
+
+---
+
+## Limitations
+
+Cell values are rendered as **plain text only**. Markdown syntax, HTML tags, and shortcode calls in data values are not processed -- they appear as literal strings in the output. If you need rich formatting in a table, use a standard Markdown table or the `table` shortcode instead.

--- a/exampleSite/content/theme-overview/data-tables.md
+++ b/exampleSite/content/theme-overview/data-tables.md
@@ -1,0 +1,141 @@
+---
+title: "Data Tables"
+weight: 500
+toc: true
+---
+
+## Overview
+
+The `data-table` shortcode renders tables from JSON, CSV, or YAML data files stored in the `assets/` directory.
+Tables are fully rendered at build time as static HTML.
+Setting `interactive="true"` progressively enhances the table with client-side column sorting -- without JavaScript, the table remains fully readable.
+
+---
+
+## Parameters
+
+{{< data-table path="/data/data-table-params.csv" variant="wide" >}}
+
+---
+
+## Data formats
+
+Place data files anywhere inside your project's `assets/` directory. The `path` parameter is relative to `assets/`.
+
+### JSON
+
+An array of objects. Keys become column headers, transformed with `humanize` and `title` (e.g., `rate_limit` becomes "Rate Limit").
+
+```json
+[
+  { "endpoint": "/api/v1/users", "method": "GET", "status": "stable" },
+  { "endpoint": "/api/v1/groups", "method": "POST", "status": "beta" }
+]
+```
+
+### CSV
+
+Standard CSV with a header row. **Headers are used exactly as written** -- no transformation is applied.
+
+```text
+Endpoint,Method,Status
+/api/v1/users,GET,stable
+/api/v1/groups,POST,beta
+```
+
+### YAML
+
+An array of objects, same structure as JSON. Keys are transformed the same way as JSON.
+
+```yaml
+- endpoint: /api/v1/users
+  method: GET
+  status: stable
+- endpoint: /api/v1/groups
+  method: POST
+  status: beta
+```
+
+---
+
+## Examples
+
+### Static table (default)
+
+The simplest usage -- renders all columns from a JSON file as a static table.
+
+```text
+{{</* data-table path="/data/api-endpoints.json" */>}}
+```
+
+{{< data-table path="/data/api-endpoints.json" >}}
+
+### Selecting columns
+
+Use `columns` to show only specific columns, in the order listed.
+
+```text
+{{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,status" */>}}
+```
+
+{{< data-table path="/data/api-endpoints.json" columns="endpoint,method,status" >}}
+
+### Hiding columns
+
+Use `hide` to remove specific columns while keeping all others.
+
+```text
+{{</* data-table path="/data/api-endpoints.json" hide="auth,rate_limit" */>}}
+```
+
+{{< data-table path="/data/api-endpoints.json" hide="auth,rate_limit" >}}
+
+### Overriding column headers
+
+Use `labels` to override auto-generated headers. The format is `key:Display Label` pairs, comma-separated.
+
+```text
+{{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,rate_limit" labels="rate_limit:Throttle" */>}}
+```
+
+{{< data-table path="/data/api-endpoints.json" columns="endpoint,method,rate_limit" labels="rate_limit:Throttle" >}}
+
+### Narrow variant
+
+Use `variant="narrow"` to constrain the table to two-thirds width.
+
+```text
+{{</* data-table path="/data/api-endpoints.json" columns="endpoint,method,status" variant="narrow" */>}}
+```
+
+{{< data-table path="/data/api-endpoints.json" columns="endpoint,method,status" variant="narrow" >}}
+
+### CSV source
+
+CSV headers appear exactly as written in the file.
+
+```text
+{{</* data-table path="/data/release-matrix.csv" */>}}
+```
+
+{{< data-table path="/data/release-matrix.csv" >}}
+
+### Sortable table
+
+Add `interactive="true"` to enable clickable column headers. Click a header to sort ascending; click again for descending.
+
+```text
+{{</* data-table path="/data/api-endpoints.json" interactive="true" */>}}
+```
+
+{{< data-table path="/data/api-endpoints.json" interactive="true" >}}
+
+### Sortable with a default sort
+
+Use `sort` to set the initial sort column. Append `:asc` or `:desc` for direction (default is ascending).
+
+```text
+{{</* data-table path="/data/release-matrix.csv" interactive="true" sort="Version:desc" */>}}
+```
+
+{{< data-table path="/data/release-matrix.csv" interactive="true" sort="Version:desc" >}}

--- a/exampleSite/content/theme-overview/data-tables/index.md
+++ b/exampleSite/content/theme-overview/data-tables/index.md
@@ -6,7 +6,8 @@ toc: true
 
 ## Overview
 
-The `data-table` shortcode renders tables from JSON, CSV, or YAML data files stored in the `assets/` directory.
+The `data-table` shortcode renders tables from JSON, CSV, or YAML data files.
+Data files are resolved from the **page bundle** first, then the global **assets/** directory.
 Tables are fully rendered at build time as static HTML.
 Setting `interactive="true"` progressively enhances the table with client-side column sorting -- without JavaScript, the table remains fully readable.
 
@@ -18,9 +19,35 @@ Setting `interactive="true"` progressively enhances the table with client-side c
 
 ---
 
-## Data formats
+## Data file location
 
-Place data files anywhere inside your project's `assets/` directory. The `path` parameter is relative to `assets/` and conventionally starts with a `/` (e.g., `/data/endpoints.json`).
+The shortcode looks for data files in two places, in order:
+
+1. **Page bundle** -- files co-located with the page's `index.md`. Use this for page-specific data.
+2. **Global assets** -- the project's `assets/` directory (or any directory mounted to it). Use this for shared data.
+
+For page bundles, the path is relative to the bundle directory. For global assets, the path is relative to `assets/` and conventionally starts with a `/` (e.g., `/data/endpoints.json`).
+
+### Page bundle example
+
+```text
+content/
+└── my-page/
+    ├── index.md        <-- {{</* data-table path="results.json" */>}}
+    └── results.json    <-- resolved from page bundle
+```
+
+### Global assets example
+
+```text
+assets/
+└── data/
+    └── endpoints.json  <-- {{</* data-table path="/data/endpoints.json" */>}}
+```
+
+---
+
+## Data formats
 
 ### JSON
 
@@ -69,6 +96,16 @@ The simplest usage -- renders all columns from a JSON file as a static table. Co
 ```
 
 {{< data-table path="/data/api-endpoints.json" >}}
+
+### Page bundle resource
+
+Data files co-located with the page's `index.md` are resolved automatically. This `team.yaml` file lives in the same directory as this page.
+
+```text
+{{</* data-table path="team.yaml" */>}}
+```
+
+{{< data-table path="team.yaml" >}}
 
 ### Selecting columns and controlling order
 
@@ -231,6 +268,16 @@ Escape sequences work in both the key and value portions of `labels`.
 ```
 
 {{< data-table path="/data/edge-cases.json" hide="col\:with\:colons,col\,with\,commas" >}}
+
+---
+
+## Warnings and validation
+
+The shortcode produces build-time warnings for common mistakes:
+
+- **Duplicate column headers.** Duplicate keys in the `labels` parameter or duplicate CSV column headers trigger a warning. The first occurrence wins.
+- **Invalid sort column.** If the `sort` column does not exist in the data, a warning is emitted and no sort is applied.
+- **Invalid sort direction.** If the sort direction is not `asc` or `desc`, a warning is emitted and the default (`asc`) is used.
 
 ---
 

--- a/exampleSite/content/theme-overview/data-tables/team.yaml
+++ b/exampleSite/content/theme-overview/data-tables/team.yaml
@@ -1,0 +1,9 @@
+- name: Alice
+  role: Engineering
+  location: Portland
+- name: Bob
+  role: Design
+  location: Austin
+- name: Carol
+  role: Product
+  location: Seattle

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -56,6 +56,12 @@
   <script src="{{ $redoc.RelPermalink }}" type="text/javascript"></script>
 {{ end }}
 
+<!-- load data-table.js (conditional) -->
+{{ if .Page.Store.Get "hasDataTable" }}
+{{ $dataTable := resources.Get "js/data-table.js" | minify | fingerprint "sha512" }}
+<script src="{{ $dataTable.RelPermalink }}" type="text/javascript" integrity="{{ $dataTable.Data.Integrity }}"></script>
+{{ end }}
+
 <!-- Load Sidebar v2 javascript -->
 {{ $jsSidebarV2 := resources.Get "js/sidebar-v2.js" | minify | fingerprint "sha512" }}
 <script src="{{ $jsSidebarV2.RelPermalink }}" type="text/javascript" integrity="{{ $jsSidebarV2.Data.Integrity }}"></script>

--- a/layouts/shortcodes/data-table.html
+++ b/layouts/shortcodes/data-table.html
@@ -11,12 +11,22 @@
     columns     (optional) - Comma-separated list of columns to display (default: all)
     hide        (optional) - Comma-separated list of columns to hide
     labels      (optional) - Column label overrides: "col:Label,col2:Label 2"
+                             Use \, to escape commas and \: to escape colons in values.
     variant     (optional) - Layout variant: "narrow" or "wide" (default: "wide")
     theme       (optional) - Table theme: "bordered" or "borderless" (default: "bordered")
+    humanize    (optional) - Humanize JSON/YAML keys for headers: "true" or "false" (default: "true")
+    markdownify (optional) - Process cell values as markdown: "true" or "false" (default: "false")
 
   Data formats: .json (array of objects), .csv (with header row), .yaml/.yml (array of objects)
   CSV headers are used verbatim. JSON/YAML keys get humanize + title case.
+
+  Escape sequences: Use \, for literal commas and \: for literal colons in parameter
+  values that are split on those characters (labels, columns, hide, sort).
 */ -}}
+
+{{- /* Sentinel characters for escape handling (\, and \:) */ -}}
+{{- $commaEsc := "\u001E" -}}{{- /* ASCII Record Separator */ -}}
+{{- $colonEsc := "\u001F" -}}{{- /* ASCII Unit Separator */ -}}
 
 {{- /* Read parameters */ -}}
 {{- $path := .Get "path" -}}
@@ -27,6 +37,8 @@
 {{- $labelsParam := .Get "labels" | default "" -}}
 {{- $variant := .Get "variant" | default "wide" -}}
 {{- $theme := .Get "theme" | default "bordered" -}}
+{{- $humanize := eq (.Get "humanize" | default "true") "true" -}}
+{{- $markdownify := eq (.Get "markdownify" | default "false") "true" -}}
 
 {{- /* Validate variant */ -}}
 {{- $validVariants := slice "narrow" "wide" -}}
@@ -47,12 +59,22 @@
 {{- end -}}
 
 {{- /* Build column label lookup from "col:Label,col2:Label 2" format */ -}}
+{{- /* Supports \, and \: escape sequences for literal commas and colons */ -}}
 {{- $labelMap := dict -}}
 {{- if $labelsParam -}}
-  {{- range split $labelsParam "," -}}
+  {{- $escaped := replace $labelsParam `\,` $commaEsc -}}
+  {{- $escaped = replace $escaped `\:` $colonEsc -}}
+  {{- range split $escaped "," -}}
     {{- $pair := split (strings.TrimSpace .) ":" -}}
     {{- if ge (len $pair) 2 -}}
-      {{- $labelMap = merge $labelMap (dict (index $pair 0) (index $pair 1)) -}}
+      {{- $key := replace (index $pair 0) $colonEsc ":" -}}
+      {{- $key = replace $key $commaEsc "," -}}
+      {{- /* Rejoin remaining parts in case value contained unescaped colons */ -}}
+      {{- $valParts := after 1 $pair -}}
+      {{- $val := delimit $valParts ":" -}}
+      {{- $val = replace $val $colonEsc ":" -}}
+      {{- $val = replace $val $commaEsc "," -}}
+      {{- $labelMap = merge $labelMap (dict $key $val) -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -119,20 +141,28 @@
 {{- /* Apply column selection */ -}}
 {{- $displayColumns := $allColumns -}}
 {{- if $columnsParam -}}
-  {{- $displayColumns = split $columnsParam "," -}}
+  {{- $escaped := replace $columnsParam `\,` $commaEsc -}}
+  {{- $escaped = replace $escaped `\:` $colonEsc -}}
+  {{- $displayColumns = split $escaped "," -}}
   {{- $trimmed := slice -}}
   {{- range $displayColumns -}}
-    {{- $trimmed = $trimmed | append (strings.TrimSpace .) -}}
+    {{- $col := replace (strings.TrimSpace .) $commaEsc "," -}}
+    {{- $col = replace $col $colonEsc ":" -}}
+    {{- $trimmed = $trimmed | append $col -}}
   {{- end -}}
   {{- $displayColumns = $trimmed -}}
 {{- end -}}
 
 {{- /* Apply column hiding */ -}}
 {{- if $hideParam -}}
-  {{- $hideCols := split $hideParam "," -}}
+  {{- $escaped := replace $hideParam `\,` $commaEsc -}}
+  {{- $escaped = replace $escaped `\:` $colonEsc -}}
+  {{- $hideCols := split $escaped "," -}}
   {{- $hideSet := slice -}}
   {{- range $hideCols -}}
-    {{- $hideSet = $hideSet | append (strings.TrimSpace .) -}}
+    {{- $col := replace (strings.TrimSpace .) $commaEsc "," -}}
+    {{- $col = replace $col $colonEsc ":" -}}
+    {{- $hideSet = $hideSet | append $col -}}
   {{- end -}}
   {{- $filtered := slice -}}
   {{- range $col := $displayColumns -}}
@@ -147,8 +177,9 @@
 {{- $sortCol := "" -}}
 {{- $sortDir := "asc" -}}
 {{- if $defaultSort -}}
-  {{- $sortParts := split $defaultSort ":" -}}
-  {{- $sortCol = index $sortParts 0 -}}
+  {{- $escaped := replace $defaultSort `\:` $colonEsc -}}
+  {{- $sortParts := split $escaped ":" -}}
+  {{- $sortCol = replace (index $sortParts 0) $colonEsc ":" -}}
   {{- if gt (len $sortParts) 1 -}}
     {{- $sortDir = index $sortParts 1 -}}
   {{- end -}}
@@ -179,7 +210,7 @@
             {{- if eq $col $sortCol }} aria-sort="{{ if eq $sortDir "desc" }}descending{{ else }}ascending{{ end }}"{{ end -}}
           >
             <span class="data-table-th-content">
-              <span class="data-table-th-label">{{ with index $labelMap $col }}{{ . }}{{ else }}{{ if $isCSV }}{{ $col }}{{ else }}{{ humanize $col | title }}{{ end }}{{ end }}</span>
+              <span class="data-table-th-label">{{ with index $labelMap $col }}{{ . }}{{ else }}{{ if or $isCSV (not $humanize) }}{{ $col }}{{ else }}{{ humanize $col | title }}{{ end }}{{ end }}</span>
               <span class="data-table-sort-icon data-table-sort-icon--none" aria-hidden="true">{{ partial "lucide" (dict "context" $ "icon" "arrow-up-down") }}</span>
               <span class="data-table-sort-icon data-table-sort-icon--asc" aria-hidden="true">{{ partial "lucide" (dict "context" $ "icon" "arrow-up") }}</span>
               <span class="data-table-sort-icon data-table-sort-icon--desc" aria-hidden="true">{{ partial "lucide" (dict "context" $ "icon" "arrow-down") }}</span>
@@ -191,15 +222,15 @@
       <tbody>
         {{- range $row := $data }}
         <tr>
-          {{- range $col := $displayColumns }}
-          <td>{{ index $row $col }}</td>
-          {{- end }}
-        </tr>
-        {{- end }}
-      </tbody>
-    </table>
-  </div>
-  <noscript>
+           {{- range $col := $displayColumns }}
+           <td>{{ if $markdownify }}{{ index $row $col | markdownify }}{{ else }}{{ index $row $col }}{{ end }}</td>
+           {{- end }}
+         </tr>
+         {{- end }}
+       </tbody>
+     </table>
+   </div>
+   <noscript>
     <p class="data-table-noscript">Enable JavaScript for column sorting.</p>
   </noscript>
 </div>
@@ -210,19 +241,19 @@
     <thead>
       <tr>
         {{- range $col := $displayColumns }}
-        <th scope="col">{{ with index $labelMap $col }}{{ . }}{{ else }}{{ if $isCSV }}{{ $col }}{{ else }}{{ humanize $col | title }}{{ end }}{{ end }}</th>
+        <th scope="col">{{ with index $labelMap $col }}{{ . }}{{ else }}{{ if or $isCSV (not $humanize) }}{{ $col }}{{ else }}{{ humanize $col | title }}{{ end }}{{ end }}</th>
         {{- end }}
       </tr>
     </thead>
     <tbody>
       {{- range $row := $data }}
       <tr>
-        {{- range $col := $displayColumns }}
-        <td>{{ index $row $col }}</td>
-        {{- end }}
-      </tr>
-      {{- end }}
-    </tbody>
-  </table>
-</div>
-{{- end -}}
+         {{- range $col := $displayColumns }}
+         <td>{{ if $markdownify }}{{ index $row $col | markdownify }}{{ else }}{{ index $row $col }}{{ end }}</td>
+         {{- end }}
+       </tr>
+       {{- end }}
+     </tbody>
+   </table>
+ </div>
+ {{- end -}}

--- a/layouts/shortcodes/data-table.html
+++ b/layouts/shortcodes/data-table.html
@@ -12,6 +12,7 @@
     hide        (optional) - Comma-separated list of columns to hide
     labels      (optional) - Column label overrides: "col:Label,col2:Label 2"
     variant     (optional) - Layout variant: "narrow" or "wide" (default: "wide")
+    theme       (optional) - Table theme: "bordered" or "borderless" (default: "bordered")
 
   Data formats: .json (array of objects), .csv (with header row), .yaml/.yml (array of objects)
   CSV headers are used verbatim. JSON/YAML keys get humanize + title case.
@@ -25,11 +26,18 @@
 {{- $hideParam := .Get "hide" | default "" -}}
 {{- $labelsParam := .Get "labels" | default "" -}}
 {{- $variant := .Get "variant" | default "wide" -}}
+{{- $theme := .Get "theme" | default "bordered" -}}
 
 {{- /* Validate variant */ -}}
 {{- $validVariants := slice "narrow" "wide" -}}
 {{- if not (in $validVariants $variant) -}}
   {{- errorf "data-table: invalid variant '%s'. Must be 'narrow' or 'wide'." $variant -}}
+{{- end -}}
+
+{{- /* Validate theme */ -}}
+{{- $validThemes := slice "bordered" "borderless" -}}
+{{- if not (in $validThemes $theme) -}}
+  {{- errorf "data-table: invalid theme '%s'. Must be 'bordered' or 'borderless'." $theme -}}
 {{- end -}}
 
 {{- /* Map variant to data-grid value (same as table shortcode) */ -}}
@@ -161,7 +169,7 @@
 <div class="data-table-wrapper"
   {{- if $sortCol }} data-default-sort="{{ $sortCol }}" data-default-sort-dir="{{ $sortDir }}"{{ end -}}
 >
-  <div class="table bordered" data-grid="{{ $dataGrid }}">
+  <div class="table {{ $theme }}" data-grid="{{ $dataGrid }}">
     <table>
       <thead>
         <tr>
@@ -197,7 +205,7 @@
 </div>
 {{- else -}}
 {{- /* Static mode: clean table, no JS */ -}}
-<div class="table bordered" data-grid="{{ $dataGrid }}">
+<div class="table {{ $theme }}" data-grid="{{ $dataGrid }}">
   <table>
     <thead>
       <tr>

--- a/layouts/shortcodes/data-table.html
+++ b/layouts/shortcodes/data-table.html
@@ -52,6 +52,11 @@
   {{- errorf "data-table: invalid theme '%s'. Must be 'bordered' or 'borderless'." $theme -}}
 {{- end -}}
 
+{{- /* Validate required path */ -}}
+{{- if not $path -}}
+  {{- errorf "data-table shortcode requires a 'path' parameter." -}}
+{{- end -}}
+
 {{- /* Map variant to data-grid value (same as table shortcode) */ -}}
 {{- $dataGrid := "wide" -}}
 {{- if eq $variant "narrow" -}}
@@ -82,11 +87,6 @@
 {{- /* Only load JS when interactive */ -}}
 {{- if $interactive -}}
   {{- .Page.Store.Set "hasDataTable" true -}}
-{{- end -}}
-
-{{- /* Validate required path */ -}}
-{{- if not $path -}}
-  {{- errorf "data-table shortcode requires a 'path' parameter." -}}
 {{- end -}}
 
 {{- /* Strip leading /static if present (same pattern as metrics shortcode) */ -}}

--- a/layouts/shortcodes/data-table.html
+++ b/layouts/shortcodes/data-table.html
@@ -5,7 +5,7 @@
   client-side column sorting.
 
   Parameters:
-    path        (required) - Path to data file in assets/ directory
+    path        (required) - Path to data file (page bundle or assets/ directory)
     interactive (optional) - Enable sortable columns via JS ("false" default)
     sort        (optional) - Default sort column, with optional :asc or :desc suffix
     columns     (optional) - Comma-separated list of columns to display (default: all)
@@ -17,6 +17,7 @@
     humanize    (optional) - Humanize JSON/YAML keys for headers: "true" or "false" (default: "true")
     markdownify (optional) - Process cell values as markdown: "true" or "false" (default: "false")
 
+  Resource lookup: page bundle (.Page.Resources.Get) first, then global assets (resources.Get).
   Data formats: .json (array of objects), .csv (with header row), .yaml/.yml (array of objects)
   CSV headers are used verbatim. JSON/YAML keys get humanize + title case.
 
@@ -79,7 +80,11 @@
       {{- $val := delimit $valParts ":" -}}
       {{- $val = replace $val $colonEsc ":" -}}
       {{- $val = replace $val $commaEsc "," -}}
-      {{- $labelMap = merge $labelMap (dict $key $val) -}}
+      {{- if index $labelMap $key -}}
+        {{- warnf "data-table: duplicate label key '%s' in labels parameter; first value wins." $key -}}
+      {{- else -}}
+        {{- $labelMap = merge $labelMap (dict $key $val) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -89,24 +94,32 @@
   {{- .Page.Store.Set "hasDataTable" true -}}
 {{- end -}}
 
-{{- /* Strip leading /static if present (same pattern as metrics shortcode) */ -}}
-{{- $cleanPath := strings.TrimPrefix "/static" $path -}}
-
-{{- /* Load and unmarshal the data file */ -}}
-{{- $resource := resources.Get $cleanPath -}}
+{{- /* Load the data file: page bundle first, then global assets */ -}}
+{{- $resource := .Page.Resources.Get $path -}}
 {{- if not $resource -}}
-  {{- errorf "data-table: could not find resource at path '%s'. Ensure the file exists in the assets/ directory." $cleanPath -}}
+  {{- $resource = resources.Get $path -}}
+{{- end -}}
+{{- if not $resource -}}
+  {{- errorf "data-table: could not find resource at path '%s'. Place the file in the page bundle or the assets/ directory." $path -}}
 {{- end -}}
 
 {{- $data := slice -}}
 {{- $allColumns := slice -}}
-{{- $ext := path.Ext $cleanPath | lower -}}
+{{- $ext := path.Ext $path | lower -}}
 {{- $isCSV := eq $ext ".csv" -}}
 {{- if $isCSV -}}
   {{- /* CSV unmarshals as [][]string; first row is the header */ -}}
   {{- $rawCSV := $resource | transform.Unmarshal (dict "delimiter" ",") -}}
   {{- if and $rawCSV (gt (len $rawCSV) 1) -}}
     {{- $headers := index $rawCSV 0 -}}
+    {{- $seenHeaders := slice -}}
+    {{- range $col := $headers -}}
+      {{- if in $seenHeaders $col -}}
+        {{- warnf "data-table: duplicate CSV column header '%s'; first occurrence wins." $col -}}
+      {{- else -}}
+        {{- $seenHeaders = $seenHeaders | append $col -}}
+      {{- end -}}
+    {{- end -}}
     {{- $allColumns = $headers -}}
     {{- range $i, $row := $rawCSV -}}
       {{- if gt $i 0 -}}
@@ -135,7 +148,7 @@
 {{- end -}}
 
 {{- if not $data -}}
-  {{- errorf "data-table: failed to unmarshal data from '%s'. Check file format." $cleanPath -}}
+  {{- errorf "data-table: failed to unmarshal data from '%s'. Check file format." $path -}}
 {{- end -}}
 
 {{- /* Apply column selection */ -}}
@@ -181,79 +194,73 @@
   {{- $sortParts := split $escaped ":" -}}
   {{- $sortCol = replace (index $sortParts 0) $colonEsc ":" -}}
   {{- if gt (len $sortParts) 1 -}}
-    {{- $sortDir = index $sortParts 1 -}}
+    {{- $rawDir := index $sortParts 1 -}}
+    {{- if in (slice "asc" "desc") $rawDir -}}
+      {{- $sortDir = $rawDir -}}
+    {{- else -}}
+      {{- warnf "data-table: invalid sort direction '%s'; must be 'asc' or 'desc'. Defaulting to 'asc'." $rawDir -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 
 {{- if $sortCol -}}
-  {{- if eq $sortDir "desc" -}}
+  {{- if not (in $displayColumns $sortCol) -}}
+    {{- warnf "data-table: sort column '%s' does not exist in the data." $sortCol -}}
+  {{- else if eq $sortDir "desc" -}}
     {{- $data = sort $data $sortCol "desc" -}}
   {{- else -}}
     {{- $data = sort $data $sortCol -}}
   {{- end -}}
 {{- end -}}
 
-{{- /* Helper: resolve display label for a column */ -}}
-{{- /* --- Render --- */ -}}
+{{- /* --- Render ---
+     Column header labels are resolved by: labelMap override > raw key (CSV/no humanize) > humanize+title.
+     Interactive mode adds a wrapper div with data attrs, sort icons, and aria-sort on headers.
+*/ -}}
 {{- if $interactive -}}
-{{- /* Interactive mode: wrapper with data attrs for JS enhancement */ -}}
 <div class="data-table-wrapper"
   {{- if $sortCol }} data-default-sort="{{ $sortCol }}" data-default-sort-dir="{{ $sortDir }}"{{ end -}}
 >
-  <div class="table {{ $theme }}" data-grid="{{ $dataGrid }}">
-    <table>
-      <thead>
-        <tr>
-          {{- range $col := $displayColumns }}
-          <th scope="col"
-            data-column="{{ $col }}"
-            {{- if eq $col $sortCol }} aria-sort="{{ if eq $sortDir "desc" }}descending{{ else }}ascending{{ end }}"{{ end -}}
-          >
-            <span class="data-table-th-content">
-              <span class="data-table-th-label">{{ with index $labelMap $col }}{{ . }}{{ else }}{{ if or $isCSV (not $humanize) }}{{ $col }}{{ else }}{{ humanize $col | title }}{{ end }}{{ end }}</span>
-              <span class="data-table-sort-icon data-table-sort-icon--none" aria-hidden="true">{{ partial "lucide" (dict "context" $ "icon" "arrow-up-down") }}</span>
-              <span class="data-table-sort-icon data-table-sort-icon--asc" aria-hidden="true">{{ partial "lucide" (dict "context" $ "icon" "arrow-up") }}</span>
-              <span class="data-table-sort-icon data-table-sort-icon--desc" aria-hidden="true">{{ partial "lucide" (dict "context" $ "icon" "arrow-down") }}</span>
-            </span>
-          </th>
-          {{- end }}
-        </tr>
-      </thead>
-      <tbody>
-        {{- range $row := $data }}
-        <tr>
-           {{- range $col := $displayColumns }}
-           <td>{{ if $markdownify }}{{ index $row $col | markdownify }}{{ else }}{{ index $row $col }}{{ end }}</td>
-           {{- end }}
-         </tr>
-         {{- end }}
-       </tbody>
-     </table>
-   </div>
-   <noscript>
-    <p class="data-table-noscript">Enable JavaScript for column sorting.</p>
-  </noscript>
-</div>
-{{- else -}}
-{{- /* Static mode: clean table, no JS */ -}}
+{{- end }}
 <div class="table {{ $theme }}" data-grid="{{ $dataGrid }}">
   <table>
     <thead>
       <tr>
         {{- range $col := $displayColumns }}
-        <th scope="col">{{ with index $labelMap $col }}{{ . }}{{ else }}{{ if or $isCSV (not $humanize) }}{{ $col }}{{ else }}{{ humanize $col | title }}{{ end }}{{ end }}</th>
+        {{- $label := $col -}}
+        {{- with index $labelMap $col }}{{ $label = . }}{{ else }}{{ if and (not $isCSV) $humanize }}{{ $label = humanize $col | title }}{{ end }}{{ end -}}
+        {{- if $interactive }}
+        <th scope="col"
+          data-column="{{ $col }}"
+          {{- if eq $col $sortCol }} aria-sort="{{ if eq $sortDir "desc" }}descending{{ else }}ascending{{ end }}"{{ end -}}
+        >
+          <span class="data-table-th-content">
+            <span class="data-table-th-label">{{ $label }}</span>
+            <span class="data-table-sort-icon data-table-sort-icon--none" aria-hidden="true">{{ partial "lucide" (dict "context" $ "icon" "arrow-up-down") }}</span>
+            <span class="data-table-sort-icon data-table-sort-icon--asc" aria-hidden="true">{{ partial "lucide" (dict "context" $ "icon" "arrow-up") }}</span>
+            <span class="data-table-sort-icon data-table-sort-icon--desc" aria-hidden="true">{{ partial "lucide" (dict "context" $ "icon" "arrow-down") }}</span>
+          </span>
+        </th>
+        {{- else }}
+        <th scope="col">{{ $label }}</th>
+        {{- end }}
         {{- end }}
       </tr>
     </thead>
     <tbody>
       {{- range $row := $data }}
       <tr>
-         {{- range $col := $displayColumns }}
-         <td>{{ if $markdownify }}{{ index $row $col | markdownify }}{{ else }}{{ index $row $col }}{{ end }}</td>
-         {{- end }}
-       </tr>
-       {{- end }}
-     </tbody>
-   </table>
- </div>
- {{- end -}}
+        {{- range $col := $displayColumns }}
+        <td>{{ if $markdownify }}{{ index $row $col | markdownify }}{{ else }}{{ index $row $col }}{{ end }}</td>
+        {{- end }}
+      </tr>
+      {{- end }}
+    </tbody>
+  </table>
+</div>
+{{- if $interactive }}
+  <noscript>
+    <p class="data-table-noscript">Enable JavaScript for column sorting.</p>
+  </noscript>
+</div>
+{{- end -}}

--- a/layouts/shortcodes/data-table.html
+++ b/layouts/shortcodes/data-table.html
@@ -1,0 +1,220 @@
+{{- /*
+  data-table shortcode
+  Renders a table from a JSON, CSV, or YAML data file.
+  By default renders a plain static table. Set interactive="true" to enable
+  client-side column sorting.
+
+  Parameters:
+    path        (required) - Path to data file in assets/ directory
+    interactive (optional) - Enable sortable columns via JS ("false" default)
+    sort        (optional) - Default sort column, with optional :asc or :desc suffix
+    columns     (optional) - Comma-separated list of columns to display (default: all)
+    hide        (optional) - Comma-separated list of columns to hide
+    labels      (optional) - Column label overrides: "col:Label,col2:Label 2"
+    variant     (optional) - Layout variant: "narrow" or "wide" (default: "wide")
+
+  Data formats: .json (array of objects), .csv (with header row), .yaml/.yml (array of objects)
+  CSV headers are used verbatim. JSON/YAML keys get humanize + title case.
+*/ -}}
+
+{{- /* Read parameters */ -}}
+{{- $path := .Get "path" -}}
+{{- $interactive := eq (.Get "interactive" | default "false") "true" -}}
+{{- $defaultSort := .Get "sort" | default "" -}}
+{{- $columnsParam := .Get "columns" | default "" -}}
+{{- $hideParam := .Get "hide" | default "" -}}
+{{- $labelsParam := .Get "labels" | default "" -}}
+{{- $variant := .Get "variant" | default "wide" -}}
+
+{{- /* Validate variant */ -}}
+{{- $validVariants := slice "narrow" "wide" -}}
+{{- if not (in $validVariants $variant) -}}
+  {{- errorf "data-table: invalid variant '%s'. Must be 'narrow' or 'wide'." $variant -}}
+{{- end -}}
+
+{{- /* Map variant to data-grid value (same as table shortcode) */ -}}
+{{- $dataGrid := "wide" -}}
+{{- if eq $variant "narrow" -}}
+  {{- $dataGrid = "first-two-thirds" -}}
+{{- end -}}
+
+{{- /* Build column label lookup from "col:Label,col2:Label 2" format */ -}}
+{{- $labelMap := dict -}}
+{{- if $labelsParam -}}
+  {{- range split $labelsParam "," -}}
+    {{- $pair := split (strings.TrimSpace .) ":" -}}
+    {{- if ge (len $pair) 2 -}}
+      {{- $labelMap = merge $labelMap (dict (index $pair 0) (index $pair 1)) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Only load JS when interactive */ -}}
+{{- if $interactive -}}
+  {{- .Page.Store.Set "hasDataTable" true -}}
+{{- end -}}
+
+{{- /* Validate required path */ -}}
+{{- if not $path -}}
+  {{- errorf "data-table shortcode requires a 'path' parameter." -}}
+{{- end -}}
+
+{{- /* Strip leading /static if present (same pattern as metrics shortcode) */ -}}
+{{- $cleanPath := strings.TrimPrefix "/static" $path -}}
+
+{{- /* Load and unmarshal the data file */ -}}
+{{- $resource := resources.Get $cleanPath -}}
+{{- if not $resource -}}
+  {{- errorf "data-table: could not find resource at path '%s'. Ensure the file exists in the assets/ directory." $cleanPath -}}
+{{- end -}}
+
+{{- $data := slice -}}
+{{- $allColumns := slice -}}
+{{- $ext := path.Ext $cleanPath | lower -}}
+{{- $isCSV := eq $ext ".csv" -}}
+{{- if $isCSV -}}
+  {{- /* CSV unmarshals as [][]string; first row is the header */ -}}
+  {{- $rawCSV := $resource | transform.Unmarshal (dict "delimiter" ",") -}}
+  {{- if and $rawCSV (gt (len $rawCSV) 1) -}}
+    {{- $headers := index $rawCSV 0 -}}
+    {{- $allColumns = $headers -}}
+    {{- range $i, $row := $rawCSV -}}
+      {{- if gt $i 0 -}}
+        {{- $rowMap := dict -}}
+        {{- range $j, $col := $headers -}}
+          {{- $val := "" -}}
+          {{- if lt $j (len $row) -}}
+            {{- $val = index $row $j -}}
+          {{- end -}}
+          {{- $rowMap = merge $rowMap (dict $col $val) -}}
+        {{- end -}}
+        {{- $data = $data | append $rowMap -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- else -}}
+  {{- $data = $resource | transform.Unmarshal -}}
+  {{- /* Determine columns from first row of map data */ -}}
+  {{- with index $data 0 -}}
+    {{- range $key, $_ := . -}}
+      {{- $allColumns = $allColumns | append $key -}}
+    {{- end -}}
+  {{- end -}}
+  {{- /* Sort columns alphabetically for consistent ordering */ -}}
+  {{- $allColumns = sort $allColumns -}}
+{{- end -}}
+
+{{- if not $data -}}
+  {{- errorf "data-table: failed to unmarshal data from '%s'. Check file format." $cleanPath -}}
+{{- end -}}
+
+{{- /* Apply column selection */ -}}
+{{- $displayColumns := $allColumns -}}
+{{- if $columnsParam -}}
+  {{- $displayColumns = split $columnsParam "," -}}
+  {{- $trimmed := slice -}}
+  {{- range $displayColumns -}}
+    {{- $trimmed = $trimmed | append (strings.TrimSpace .) -}}
+  {{- end -}}
+  {{- $displayColumns = $trimmed -}}
+{{- end -}}
+
+{{- /* Apply column hiding */ -}}
+{{- if $hideParam -}}
+  {{- $hideCols := split $hideParam "," -}}
+  {{- $hideSet := slice -}}
+  {{- range $hideCols -}}
+    {{- $hideSet = $hideSet | append (strings.TrimSpace .) -}}
+  {{- end -}}
+  {{- $filtered := slice -}}
+  {{- range $col := $displayColumns -}}
+    {{- if not (in $hideSet $col) -}}
+      {{- $filtered = $filtered | append $col -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $displayColumns = $filtered -}}
+{{- end -}}
+
+{{- /* Parse and apply default sort at build time */ -}}
+{{- $sortCol := "" -}}
+{{- $sortDir := "asc" -}}
+{{- if $defaultSort -}}
+  {{- $sortParts := split $defaultSort ":" -}}
+  {{- $sortCol = index $sortParts 0 -}}
+  {{- if gt (len $sortParts) 1 -}}
+    {{- $sortDir = index $sortParts 1 -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if $sortCol -}}
+  {{- if eq $sortDir "desc" -}}
+    {{- $data = sort $data $sortCol "desc" -}}
+  {{- else -}}
+    {{- $data = sort $data $sortCol -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Helper: resolve display label for a column */ -}}
+{{- /* --- Render --- */ -}}
+{{- if $interactive -}}
+{{- /* Interactive mode: wrapper with data attrs for JS enhancement */ -}}
+<div class="data-table-wrapper"
+  {{- if $sortCol }} data-default-sort="{{ $sortCol }}" data-default-sort-dir="{{ $sortDir }}"{{ end -}}
+>
+  <div class="table bordered" data-grid="{{ $dataGrid }}">
+    <table>
+      <thead>
+        <tr>
+          {{- range $col := $displayColumns }}
+          <th scope="col"
+            data-column="{{ $col }}"
+            {{- if eq $col $sortCol }} aria-sort="{{ if eq $sortDir "desc" }}descending{{ else }}ascending{{ end }}"{{ end -}}
+          >
+            <span class="data-table-th-content">
+              <span class="data-table-th-label">{{ with index $labelMap $col }}{{ . }}{{ else }}{{ if $isCSV }}{{ $col }}{{ else }}{{ humanize $col | title }}{{ end }}{{ end }}</span>
+              <span class="data-table-sort-icon data-table-sort-icon--none" aria-hidden="true">{{ partial "lucide" (dict "context" $ "icon" "arrow-up-down") }}</span>
+              <span class="data-table-sort-icon data-table-sort-icon--asc" aria-hidden="true">{{ partial "lucide" (dict "context" $ "icon" "arrow-up") }}</span>
+              <span class="data-table-sort-icon data-table-sort-icon--desc" aria-hidden="true">{{ partial "lucide" (dict "context" $ "icon" "arrow-down") }}</span>
+            </span>
+          </th>
+          {{- end }}
+        </tr>
+      </thead>
+      <tbody>
+        {{- range $row := $data }}
+        <tr>
+          {{- range $col := $displayColumns }}
+          <td>{{ index $row $col }}</td>
+          {{- end }}
+        </tr>
+        {{- end }}
+      </tbody>
+    </table>
+  </div>
+  <noscript>
+    <p class="data-table-noscript">Enable JavaScript for column sorting.</p>
+  </noscript>
+</div>
+{{- else -}}
+{{- /* Static mode: clean table, no JS */ -}}
+<div class="table bordered" data-grid="{{ $dataGrid }}">
+  <table>
+    <thead>
+      <tr>
+        {{- range $col := $displayColumns }}
+        <th scope="col">{{ with index $labelMap $col }}{{ . }}{{ else }}{{ if $isCSV }}{{ $col }}{{ else }}{{ humanize $col | title }}{{ end }}{{ end }}</th>
+        {{- end }}
+      </tr>
+    </thead>
+    <tbody>
+      {{- range $row := $data }}
+      <tr>
+        {{- range $col := $displayColumns }}
+        <td>{{ index $row $col }}</td>
+        {{- end }}
+      </tr>
+      {{- end }}
+    </tbody>
+  </table>
+</div>
+{{- end -}}


### PR DESCRIPTION
## Summary

- Adds a `data-table` shortcode that renders JSON, CSV, or YAML data files as static HTML tables at build time
- Optional client-side column sorting via `interactive="true"` (vanilla JS, ~130 lines, conditionally loaded)
- Lucide SVG icons for sort direction indicators (arrow-up-down / arrow-up / arrow-down)

## Features

| Param | Default | Description |
|---|---|---|
| `path` | (required) | Path to data file in `assets/` |
| `interactive` | `"false"` | Enable JS column sorting |
| `sort` | none | Default sort: `"col"` or `"col:desc"` |
| `columns` | all | Comma-separated column whitelist |
| `hide` | none | Comma-separated column blacklist |
| `labels` | none | Header overrides: `"col:Label,col2:Label"` |
| `variant` | `"wide"` | `"wide"` or `"narrow"` |

## Design decisions

- **Build-time rendering** -- full `<table>` always in HTML; JS only enhances with sort. No-JS fallback is free.
- **CSV headers used verbatim** -- author controls display names. JSON/YAML keys get `humanize | title`.
- **Conditional JS loading** -- uses the same `Page.Store` pattern as mermaid; only loaded on pages that use the shortcode.
- **No external dependencies** -- vanilla JS, Hugo Pipes only, Lucide icons from existing sprite.

## Files changed

- `layouts/shortcodes/data-table.html` -- the shortcode
- `assets/js/data-table.js` -- sort logic (~130 lines)
- `assets/css/v2/style.css` -- data table styles (+80 lines)
- `layouts/partials/scripts.html` -- conditional script loading
- `exampleSite/` -- example data files + demo page

## Screenshot
<img width="828" height="902" alt="Screenshot 2026-03-12 at 2 22 43 PM" src="https://github.com/user-attachments/assets/67019422-6ff7-463c-8602-a5cc9da58642" />


