### PR TITLE
feat: replace nd- with f5-

### DIFF
--- a/exampleSite/content/nested-product/_index.md
+++ b/exampleSite/content/nested-product/_index.md
@@ -1,9 +1,9 @@
 ---
 title: Nested Product Test
-nd-subtitle: Testing nested product resolution
+f5-subtitle: Testing nested product resolution
 url: /nested/product/
 cascade:
-  nd-banner:
+  f5-banner:
     enabled: true
     start-date: 2025-01-01
     md: /_banners/test-product-intro.md

--- a/exampleSite/content/nested-product/get-help.md
+++ b/exampleSite/content/nested-product/get-help.md
@@ -2,7 +2,7 @@
 title: Get help
 weight: 750
 toc: true
-nd-docs: DOCS-882
+f5-docs: DOCS-882
 url: /nested/product/get-help/
 type:
 - how-to

--- a/exampleSite/content/nginx/installing-nginx-open-source.md
+++ b/exampleSite/content/nginx/installing-nginx-open-source.md
@@ -7,7 +7,7 @@ doctypes:
 title: Installing NGINX Open Source
 toc: true
 weight: 200
-nd-reading-time: true
+f5-reading-time: true
 ---
 
 {{<img src="hero-graphic.webp" alt="hero graphic">}}

--- a/exampleSite/content/test-product/_index.md
+++ b/exampleSite/content/test-product/_index.md
@@ -5,16 +5,16 @@ weight: 100
 # The URL is the base of the deployed path, becoming "docs.nginx.com/<url>/<other-pages>"
 url: 
 # The subtitle displays directly underneath the heading of a given page
-nd-subtitle: Test pages for nginx-hugo-theme
+f5-subtitle: Test pages for nginx-hugo-theme
 # Indicates that this is a custom landing page
-nd-landing-page: true
+f5-landing-page: true
 # Types have a 1:1 relationship with Hugo archetypes, so you shouldn't need to change this
-nd-content-type: landing-page
+f5-content-type: landing-page
 # Intended for internal catalogue and search, case sensitive:
 # Agent, N4Azure, NIC, NIM, NGF, NAP-DOS, NAP-WAF, NGINX One, NGINX+, Solutions, Unit
-nd-product:
+f5-product:
 cascade:
-  nd-banner:
+  f5-banner:
     enabled: true
     start-date: 2025-01-01
     md: /_banners/test-product-intro.md

--- a/exampleSite/content/test-product/commerical/commercial-feature.md
+++ b/exampleSite/content/test-product/commerical/commercial-feature.md
@@ -2,9 +2,9 @@
 title: Commercial Feature
 linkTitle: Feature
 description: Commercial Feature
-nd-commercial: true
+f5-commercial: true
 ---
 
 The sidebar for this item should contain _Commercial_ to signifiy that it requires a comemrical subscription.
 
-This is managed by the `nd-commercial: true` in the frontmatter.
+This is managed by the `f5-commercial: true` in the frontmatter.

--- a/exampleSite/content/test-product/commerical/partial-commercial-feature.md
+++ b/exampleSite/content/test-product/commerical/partial-commercial-feature.md
@@ -2,7 +2,7 @@
 title: Partial Commercial Feature
 linkTitle: Feature
 description: Partial Commercial Feature
-nd-commercial-partial: true
+f5-commercial-partial: true
 ---
 
 The sidebar for this item should contain _Partial Commercial_ to signifiy that it requires a commercial subscription
@@ -11,4 +11,4 @@ for a part of this page.
 For example, a module may have specific features or directives within, that
 require a commercial subscription, but the module itself can be used without it.
 
-This is managed by the `nd-commercial-partial: true` in the frontmatter.
+This is managed by the `f5-commercial-partial: true` in the frontmatter.

--- a/exampleSite/content/test-product/redoc/api-reference.md
+++ b/exampleSite/content/test-product/redoc/api-reference.md
@@ -7,7 +7,7 @@ tags:
   - api
 doctypes:
   - reference
-nd-api-reference: "./api/example.json"
+f5-api-reference: "./api/example.json"
 ---
 
 ## Introduction

--- a/exampleSite/content/test-product/redoc/live-example.md
+++ b/exampleSite/content/test-product/redoc/live-example.md
@@ -7,5 +7,5 @@ tags:
   - api
 doctypes:
   - reference
-nd-api-reference: "./api/one.json"
+f5-api-reference: "./api/one.json"
 ---

--- a/exampleSite/content/theme-overview/_index.md
+++ b/exampleSite/content/theme-overview/_index.md
@@ -5,11 +5,11 @@ weight: 100
 # The URL is the base of the deployed path, becoming "<baseurl>/<url>/<other-pages>"
 url: 
 # The subtitle displays directly underneath the heading of a given page
-nd-subtitle: An overview of information for the nginx-hugo-theme
+f5-subtitle: An overview of information for the nginx-hugo-theme
 # Indicates that this is a custom landing page
-nd-landing-page: true
+f5-landing-page: true
 # Types have a 1:1 relationship with Hugo archetypes, so you shouldn't need to change this
-nd-content-type: landing-page
+f5-content-type: landing-page
 ---
 
 The nginx-hugo-theme is a [Hugo Theme](https://gohugo.io/getting-started/directory-structure/#theme-skeleton) originally made for [NGINX docs](https://docs.nginx.com), and known internally as `mainframe`.
@@ -30,9 +30,9 @@ weight: 100
 # The URL is the base of the deployed path, becoming "<baseurl>/<url>/<other-pages>"
 url: 
 # The subtitle displays directly underneath the heading of a given page
-nd-subtitle: An overview of information for the nginx-hugo-theme
+f5-subtitle: An overview of information for the nginx-hugo-theme
 # Indicates that this is a custom landing page
-nd-landing-page: true
+f5-landing-page: true
 # Types have a 1:1 relationship with Hugo archetypes, so you shouldn't need to change this
-nd-content-type: landing-page
+f5-content-type: landing-page
 ```

--- a/exampleSite/content/theme-overview/custom-frontmatter/_index.md
+++ b/exampleSite/content/theme-overview/custom-frontmatter/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Frontmatter
 weight: 100
-nd-landing-page: true
+f5-landing-page: true
 ---
 
 ## Custom fields

--- a/exampleSite/content/theme-overview/custom-frontmatter/custom-landing-page/_index.md
+++ b/exampleSite/content/theme-overview/custom-frontmatter/custom-landing-page/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Custom landing page
-nd-landing-page: true
-nd-subtitle: This is a subtitle for a landing page
+f5-landing-page: true
+f5-subtitle: This is a subtitle for a landing page
 ---
 
 This is a custom landing page.

--- a/exampleSite/content/theme-overview/custom-frontmatter/default-landing-page/_index.md
+++ b/exampleSite/content/theme-overview/custom-frontmatter/default-landing-page/_index.md
@@ -1,4 +1,4 @@
 ---
 title: Default landing page
-nd-subtitle: This is a subtitle for a landing page
+f5-subtitle: This is a subtitle for a landing page
 ---

--- a/exampleSite/content/theme-overview/custom-frontmatter/landing-pages.md
+++ b/exampleSite/content/theme-overview/custom-frontmatter/landing-pages.md
@@ -1,6 +1,6 @@
 ---
 title: Landing pages
-nd-subtitle: This is a subtitle for a landing page
+f5-subtitle: This is a subtitle for a landing page
 toc: true
 ---
 
@@ -11,14 +11,14 @@ Landing pages (`_index.md` files) are rendered using our [list.html](https://git
 
 ## Default landing page
 
-If `_index.md_` contains _only_ frontmatter, with no content or `nd-landing-page: true`, it will render a list of the content. 
+If `_index.md_` contains _only_ frontmatter, with no content or `f5-landing-page: true`, it will render a list of the content. 
 
 The most basic `_index.md` example:
 
 ```yml
 ---
 title: Default landing page
-nd-subtitle: This is a subtitle for a landing page
+f5-subtitle: This is a subtitle for a landing page
 ---
 
 ```
@@ -35,7 +35,7 @@ This page __will not__ get linked to in the sidebar. It can only be accessed thr
 
 ## Custom landing page
 
-If the `_index.md` file contains the `nd-landing-page: true` frontmatter field, __and__ you add some content, you can customize the contents on this page.
+If the `_index.md` file contains the `f5-landing-page: true` frontmatter field, __and__ you add some content, you can customize the contents on this page.
 
 The page will also be added to the sidebar with the name of `Overview` under a section.
 
@@ -45,8 +45,8 @@ This can be treated like any other content page, and supports all expected short
 ```yml
 ---
 title: Custom landing page
-nd-landing-page: true
-nd-subtitle: This is a subtitle for a landing page
+f5-landing-page: true
+f5-subtitle: This is a subtitle for a landing page
 ---
 
 This is a custom landing page.
@@ -62,4 +62,4 @@ Note that the `Overview` section for this page is visible in the sidebar, unlike
 
 ## Custom subtitle
 
-Regardless of using default or custom landing pages, `nd-subtitle` can be used to add a custom subtitle.
+Regardless of using default or custom landing pages, `f5-subtitle` can be used to add a custom subtitle.

--- a/exampleSite/content/theme-overview/custom-frontmatter/redocly.md
+++ b/exampleSite/content/theme-overview/custom-frontmatter/redocly.md
@@ -1,19 +1,19 @@
 ---
 title: Redocly
-nd-api-reference: "./api/example.json"
+f5-api-reference: "./api/example.json"
 toc: true
 ---
 
-## nd-api-reference
+## f5-api-reference
 
-To render an OpenAPI specification using Redocly, you need to include the `nd-api-reference` front matter field, with a reference to an OpenAPI spec file.
+To render an OpenAPI specification using Redocly, you need to include the `f5-api-reference` front matter field, with a reference to an OpenAPI spec file.
 
 The front matter of this page is:
 
 ``` yml
 ---
 title: Redocly
-nd-api-reference: "./api/example.json"
+f5-api-reference: "./api/example.json"
 ---
 ```
 

--- a/exampleSite/content/theme-overview/shortcodes/_index.md
+++ b/exampleSite/content/theme-overview/shortcodes/_index.md
@@ -1,8 +1,8 @@
 ---
 title: Shortcodes
 weight: 100
-nd-subtitle: An overview of shortcodes provided by nginx-hugo-theme
-nd-landing-page: true
+f5-subtitle: An overview of shortcodes provided by nginx-hugo-theme
+f5-landing-page: true
 ---
 
 A shortcode is a [template](https://gohugo.io/quick-reference/glossary/#template) invoked within markup, accepting some arguments. These templates can be used directly in markdown files, usually in the following form:

--- a/exampleSite/content/theme-overview/sidebar/_index.md
+++ b/exampleSite/content/theme-overview/sidebar/_index.md
@@ -1,7 +1,7 @@
 ---
 title: Sidebar
 weight: 100
-nd-subtitle: An overview of sidebar usage
-nd-landing-page: true
+f5-subtitle: An overview of sidebar usage
+f5-landing-page: true
 ---
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -17,15 +17,15 @@
 
           <div class="list-header-title">
             <h1>{{ .Title }}</h1>
-            {{ if index .Params "nd-subtitle" }}
-              <p>{{ index .Params "nd-subtitle" | markdownify }}</p>
+            {{ if index .Params "f5-subtitle" }}
+              <p>{{ index .Params "f5-subtitle" | markdownify }}</p>
             {{ end }}
           </div>
         </div>
 
         {{ partial "banner" . }}
 
-        {{ $hasCustomContent := index .Params "nd-landing-page" | default false }}
+        {{ $hasCustomContent := index .Params "f5-landing-page" | default false }}
         {{ if $hasCustomContent }}
         {{ .Content }}
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -15,7 +15,7 @@
 
         <h1>{{ .Title }}</h1>
         <div class="content__reading-time">
-        {{ if index .Params "nd-reading-time" }}
+        {{ if index .Params "f5-reading-time" }}
             {{ printf "~%d min read" .ReadingTime }}
         {{ end }}
         </div>
@@ -25,7 +25,7 @@
         {{ if eq .Page.Draft true }}{{ partial "draft-badge.html" . }}{{ end }}
         {{ if in .Params.doctypes "beta" }}{{ partial "beta-badge" . }}{{ end }}
 
-        {{ with (index .Page.Params "nd-api-reference") }}
+        {{ with (index .Page.Params "f5-api-reference") }}
         <div class="content__redocly" data-grid="breakout">
             {{ partial "openapi.html" . }}
         </div>

--- a/layouts/partials/banner.html
+++ b/layouts/partials/banner.html
@@ -1,4 +1,4 @@
-{{- with index .Params "nd-banner" -}}
+{{- with index .Params "f5-banner" -}}
   {{- if .enabled -}}
     <!-- Gather the dates and default to beginning or end of time if frontmatter is not provided -->
     {{- $currentDate :=  now | dateFormat "2006-01-02" -}}

--- a/layouts/partials/commercial-feature.html
+++ b/layouts/partials/commercial-feature.html
@@ -1,7 +1,7 @@
 {{ with .Params }}
-  {{ if (index . "nd-commercial") }}
+  {{ if (index . "f5-commercial") }}
   - <em>Commercial</em>
-  {{ else if (index . "nd-commercial-partial") }}
+  {{ else if (index . "f5-commercial-partial") }}
   - <em>Partial Commercial</em>
   {{ end }}
 {{ end }}

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -52,7 +52,7 @@
 {{ $redoc := $redoc | fingerprint "sha512" }}
 
 <!-- only load the redoc js if we're on an api reference page -->
-{{ with index .Params "nd-api-reference" }}
+{{ with index .Params "f5-api-reference" }}
   <script src="{{ $redoc.RelPermalink }}" type="text/javascript"></script>
 {{ end }}
 


### PR DESCRIPTION
### Proposed changes

Replaces the use of `nd-` with `f5-` in the custom metadata keys.

To be paired with an PR that will update the nginx/documentation respository content to follow the same naming convention.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
