### PR TITLE
Add a run "once a month" cron for Lighthouse

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -5,6 +5,8 @@ on:
     branches: 
       - main
   workflow_dispatch:
+  schedule:
+    - cron: "0 0 1 * *"
 
 env:
   OWNER: nginxinc


### PR DESCRIPTION
### Proposed changes

- Due to the case that `lighthouse-reports-main` might be generated on merge to main and then more than one month (the expiration timeframe) has passed since last merge to main, it will break any workflows that rely on it with a 410. See - https://github.com/nginxinc/nginx-hugo-theme/actions/runs/25329240341/job/74258501894
- As a safeguard, we should autogenerate at the first of every month. This guarantees the artifact always exist.

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
