### PR TITLE
feat: Improve markdown pages

### DIFF
--- a/data/f5/content_types.yaml
+++ b/data/f5/content_types.yaml
@@ -1,0 +1,8 @@
+concept: Concept
+tech-specs: Technical specification
+how-to: How-to guide
+redoc: API reference
+reference: Reference
+tutorial: Tutorial
+redirect: Redirect
+landing-page: Landing page

--- a/data/f5/content_types.yaml
+++ b/data/f5/content_types.yaml
@@ -6,3 +6,5 @@ reference: Reference
 tutorial: Tutorial
 redirect: Redirect
 landing-page: Landing page
+installation-guide: Installation guide
+release-notes: Release notes

--- a/layouts/_default/list.md
+++ b/layouts/_default/list.md
@@ -1,6 +1,14 @@
 # {{ .Title }}
-{{ with .Params.description }}
-> {{ . }}
-{{- end }}
 
+{{ $header := partial "f5-doc-metadata.html" . -}}
+{{- with .Params.description -}}
+{{- $line := printf "> %s" . -}}
+{{- if $header -}}{{- $header = printf "%s\n%s" $header $line -}}{{- else -}}{{- $header = $line -}}{{- end -}}
+{{- end -}}
+{{- if $header -}}
+{{ $header }}
+
+---
+
+{{ end -}}
 {{ if .RawContent }}{{ partial "clean-content.html" . | safeHTML }}{{ else }}{{ .Params.description | safeHTML }}{{ end }}

--- a/layouts/_default/list.md
+++ b/layouts/_default/list.md
@@ -7,8 +7,6 @@
 {{- end -}}
 {{- if $header -}}
 {{ $header }}
-
----
-
+{{- printf "\n\n---\n\n" -}}
 {{ end -}}
 {{ if .RawContent }}{{ partial "clean-content.html" . | safeHTML }}{{ else }}{{ .Params.description | safeHTML }}{{ end }}

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -11,9 +11,7 @@
 {{- end -}}
 {{- if $header -}}
 {{ $header }}
-
----
-
+{{- printf "\n\n---\n\n" -}}
 {{ end -}}
 {{- $page := . -}}
 {{- $extraContent := "" -}}

--- a/layouts/_default/single.md
+++ b/layouts/_default/single.md
@@ -1,21 +1,29 @@
 # {{ .Title }}
-{{ with .Date }}
-date: {{ .Format "2006-01-02" }}
-{{- end }}
-{{ with .Params.description }}
-> {{ . }}
-{{- end }}
 
-{{ $page := . }}
-{{ $extraContent := "" }}
-{{ with .Params.contentSource }}
-    {{ with site.GetPage . }}
-        {{ $page = . }}
-        {{/* When the delegating page has its own body, render it after the sourced content */}}
-        {{ if $.RawContent }}{{ $extraContent = printf "\n\n%s" (partial "clean-content.html" $) }}{{ end }}
-    {{ else }}
-        {{ errorf "contentSource %q does not resolve to a page (referenced in %s)" . $.File.Filename }}
-    {{ end }}
-{{ end }}
+{{ $header := partial "f5-doc-metadata.html" . -}}
+{{- with .Date -}}
+{{- $line := printf "date: %s" (.Format "2006-01-02") -}}
+{{- if $header -}}{{- $header = printf "%s\n%s" $header $line -}}{{- else -}}{{- $header = $line -}}{{- end -}}
+{{- end -}}
+{{- with .Params.description -}}
+{{- $line := printf "> %s" . -}}
+{{- if $header -}}{{- $header = printf "%s\n%s" $header $line -}}{{- else -}}{{- $header = $line -}}{{- end -}}
+{{- end -}}
+{{- if $header -}}
+{{ $header }}
 
+---
+
+{{ end -}}
+{{- $page := . -}}
+{{- $extraContent := "" -}}
+{{- with .Params.contentSource -}}
+{{- with site.GetPage . -}}
+{{- $page = . -}}
+{{- /* When the delegating page has its own body, render it after the sourced content */ -}}
+{{- if $.RawContent -}}{{- $extraContent = printf "\n\n%s" (partial "clean-content.html" $) -}}{{- end -}}
+{{- else -}}
+{{- errorf "contentSource %q does not resolve to a page (referenced in %s)" . $.File.Filename -}}
+{{- end -}}
+{{- end -}}
 {{ if $page.RawContent }}{{ partial "sub-content-vars.html" (dict "content" (printf "%s%s" (partial "clean-content.html" $page) $extraContent) "page" .) | safeHTML }}{{ else }}{{ $page.Summary | plainify | safeHTML }}{{ end }}

--- a/layouts/partials/f5-doc-metadata.html
+++ b/layouts/partials/f5-doc-metadata.html
@@ -1,0 +1,20 @@
+{{- /* Renders human-readable f5-content-type / f5-product metadata lines for plain-text output formats (e.g. md). Returns "" if neither is set. */ -}}
+{{- $lines := "" -}}
+{{- with index .Params "f5-content-type" -}}
+{{- $lines = printf "Type of document: %s" (index $.Site.Data.f5.content_types . | default .) -}}
+{{- end -}}
+{{- with index .Params "f5-product" -}}
+{{- $products := . -}}
+{{- $label := "" -}}
+{{- if eq (printf "%T" $products) "string" -}}
+{{- $label = $products -}}
+{{- else -}}
+{{- range $i, $p := $products -}}
+{{- if $i -}}{{- $label = printf "%s, " $label -}}{{- end -}}
+{{- $label = printf "%s%s" $label $p -}}
+{{- end -}}
+{{- end -}}
+{{- $line := printf "Product: %s" $label -}}
+{{- if $lines -}}{{- $lines = printf "%s\n%s" $lines $line -}}{{- else -}}{{- $lines = $line -}}{{- end -}}
+{{- end -}}
+{{- $lines -}}


### PR DESCRIPTION
### Proposed changes

Improves the markdown pages that the theme generates from doc files:

- Provide basic metadata that can be useful for LLMS: Document type, product name (this is extracted from the frontmatter)
- Clean up spacing on title and metadata area of the markdown doc

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
