### PR TITLE
Fix(csp): Update CSP definitions to allow analytics scripts

### DIFF
--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -85,16 +85,16 @@
 {{ $coveoEnabled := partial "get-feature-flags.html" "disable_coveo" }}
 {{ $qualtricsEnabled := partial "get-feature-flags.html"  "disable_qualtrics" }}
 {{/* set custom CSP to load styles and scripts with special handling for GTM scripts (requires unsafe-inline) and Dev Portal page(s) (requires 'unsafe-eval') */}}
-<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'
-    https://consent.trustarc.com/ 
-    https://mktg.tags.f5.com/basic/prod/utag.sync.js 
+<meta http-equiv="Content-Security-Policy" content="
+    script-src 'self' 'unsafe-inline'
+    https://consent.trustarc.com/
     {{ if $coveoEnabled }}https://static.cloud.coveo.com/{{ end }} 
     https://*.f5.com/
     https://*.amplitude.com
     https://*.netlify.app https://gist.github.com
     https://tag.demandbase.com/pscSDsz4.min.js
     https://munchkin.brightfunnel.com/js/build/bf-munchkin.min.js
-    https://www.googletagmanager.com/gtm.js
+    https://www.googletagmanager.com/
     https://www.google-analytics.com/
     https://www.google-analytics.com/analytics.js
     https://www.google-analytics.com/plugins/ua/linkid.js
@@ -102,7 +102,7 @@
     https://cdn.bizible.com/xdc.js
     https://f5networksglobalprod.122.2o7.net/
     https://f5networksnginxdocs.122.2o7.net/
-    {{ if $qualtricsEnabled }}https://*.siteintercept.qualtrics.com/SIE/?Q_ZID=*{{ end }}
+    {{ if $qualtricsEnabled }}https://*.siteintercept.qualtrics.com/SIE{{ end }}
     {{ if $qualtricsEnabled }}https://siteintercept.qualtrics.com/{{ end }}
     {{ if in .Params.doctypes "devportal" }} 'unsafe-eval' {{end}};
     worker-src 'self' blob:">


### PR DESCRIPTION
### Proposed changes

Adjusts the CSP (specifically `script-src directive`) to include domains related to our analytics integration:
* https://www.googletagmanager.com/gtm.js -> https://www.googletagmanager.com/

Previous rule too specific, requests attempted but blocked by current CSP:
  * https://www.googletagmanager.com/gtag/js?id=G-XR2XLGX9JM&cx=c&_slc=1
  * https://www.googletagmanager.com/gtag/destination?id=UA-27974099-11&cx=c&gtm=4e6790

### Checklist

Before creating a PR, run through this checklist and mark each as complete.

- [x] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation ([`README.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/README.md) and [`CHANGELOG.md`](https://github.com/nginxinc/nginx-hugo-theme/blob/main/CHANGELOG.md))
